### PR TITLE
Mock pusher-js for integration/acceptance tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,10 +54,14 @@ namespace :acf do
       p list
     end
   end
-  
+
 end
 
 desc 'Start test server.'
 task :test do
   exec 'ruby test/app.rb'
+end
+
+task :test_mock do
+  exec 'ruby test/mock.rb'
 end

--- a/test/mock.rb
+++ b/test/mock.rb
@@ -1,0 +1,10 @@
+require 'rubygems'
+require 'bundler/setup'
+
+$:.unshift(File.expand_path('../../lib/pusher-gem/lib', __FILE__))
+
+require 'sinatra'
+
+get '/' do
+  erb :index_mock
+end

--- a/test/public/mock_test.js
+++ b/test/public/mock_test.js
@@ -1,0 +1,157 @@
+Pusher.allow_reconnect = false
+Pusher.log = function() {
+  if (window.console) console.log.apply(console, arguments)
+}
+
+WebSocket.__swfLocation = "/WebSocketMain.swf"
+
+var testTimeout = 600
+var clientID = parseInt(Math.random() * 1000000)
+var pusherAsyncTimeout = 400
+var channelCount = 0
+
+// Save generated channel in order to access it from the mock
+function nextChannel() {
+  window.channel = "test-channel-" + clientID + '-' + channelCount++
+  return window.channel
+}
+
+function onPusherReady(pusher, callback) {
+  pusher.bind("connection_established", function() {
+    callback(pusher, nextChannel())
+  })
+}
+
+// Delay helper, easier interface for settimeout.
+function delay (func, wait) {
+  var args = Array.prototype.slice.call(arguments, 2);
+  return setTimeout(function(){ return func.apply(func, args); }, wait);
+};
+
+// Async trigger function with slight delay for triggering mocked calls
+function trigger(channel, event, data, socket_id) {
+  delay (function() {
+    window.pusher_mock.dispatch_message(JSON.stringify({
+      channel: channel,
+      event: event,
+      data: data,
+      socket_id: socket_id
+    }))
+  }, 100)
+}
+
+function disconnect(pusher) {
+  setTimeout(function() {
+    pusher.disconnect()
+  }, testTimeout)
+}
+
+function pusherTest(description, expected, callback) {
+  test(description, function() {
+    stop(testTimeout)
+    var pusher = new Pusher(pusherKey)
+    onPusherReady(pusher, callback)
+    window.pusher_mock.open_connection();
+    disconnect(pusher)
+  })
+}
+
+pusherTest("should receive events from a subscribed channel", 1, function(pusher, channel) {
+  pusher.subscribe(channel).bind("test_event", function(data) {
+    same(data, { some: "data" })
+    start()
+  });
+
+  trigger(channel, "test_event", { some: "data" })
+})
+
+pusherTest("should not trigger events for channels which we aren't subscribed to", 1, function(pusher, channel) {
+  var eventCalled = false
+
+  pusher.subscribe(channel).bind("test_event", function() {
+    eventCalled = true
+  });
+
+  pusher.unsubscribe(channel)
+
+  trigger(channel, "test_event", { some: "data" })
+
+  setTimeout(function() {
+    ok(!eventCalled)
+    start()
+  }, pusherAsyncTimeout);
+})
+
+pusherTest("should only trigger events for channels which we are subscribed to", 1, function(pusher, channel) {
+  var anotherChannel = nextChannel()
+  var eventChannels = []
+
+  pusher.subscribe(channel).bind("test_event", function() {
+    eventChannels.push(channel)
+  });
+  pusher.subscribe(anotherChannel).bind("test_event", function() {
+    eventChannels.push(anotherChannel)
+  });
+
+  pusher.unsubscribe(channel)
+
+  trigger(channel, "test_event", { some: "data" })
+  trigger(anotherChannel, "test_event", { some: "data" })
+
+  setTimeout(function() {
+    same(eventChannels, [anotherChannel])
+    start()
+  }, pusherAsyncTimeout);
+})
+
+pusherTest("should trigger events for all channels which we are subscribed to", 2, function(pusher, channel) {
+  var anotherChannel = nextChannel()
+  var channelEventCalled = false
+  var anotherChannelEventCalled = false
+
+  pusher.subscribe(channel).bind("test_event", function() {
+    channelEventCalled = true
+  });
+  pusher.subscribe(anotherChannel).bind("test_event", function() {
+    anotherChannelEventCalled = true
+  });
+
+  trigger(channel, "test_event", { some: "data" })
+  trigger(anotherChannel, "test_event", { some: "data" })
+
+  setTimeout(function() {
+    ok(channelEventCalled)
+    ok(anotherChannelEventCalled)
+    start()
+  }, pusherAsyncTimeout);
+})
+
+pusherTest("should wrap event data if Pusher.data_wrapper is defined", 1, function(pusher, channel) {
+  var Wrap = function(data){
+    this.event_data = data;
+  };
+
+  Pusher.data_decorator = function(event_name, event_data){
+    if(event_name == 'wrapped_event') return new Wrap(event_data)
+    else return event_data;
+  };
+
+  pusher.subscribe(channel).bind("wrapped_event", function(wrapped_data_object) {
+    same(wrapped_data_object.event_data, { some: "data" })
+    start()
+  });
+
+  trigger(channel, "wrapped_event", { some: "data" })
+})
+
+/* Private channels :::::::::::::::::::::::::::::::: */
+pusherTest("should subscribe to private channels", 1, function(pusher, channel) {
+  pusher.subscribe('private-succesful_auth').bind("test_event", function(data) {
+    same(data, { some: "private data" })
+    start()
+  });
+
+  trigger('private-succesful_auth', "test_event", { some: "private data" })
+})
+
+

--- a/test/public/pusher_mock.js
+++ b/test/public/pusher_mock.js
@@ -1,0 +1,56 @@
+/*
+ * Pretty primitive pusher mock. Basically it disallows connections through websocket and logs all the incoming requests for future assets.
+ * It exposes pretty much the same interface as pusher would expose to sender/receiver. For now, works best with events sent from server to client
+ * side. Client to server specs & evaluation is still WIP.
+ *
+ * For Capybara tests, please usr trigger function.
+ */
+
+var PusherMock = function(pusher) {
+  this.pusher = pusher;
+}
+
+PusherMock.prototype = {
+  message_stack: [],
+  connection_open: false,
+  dispatch_message: function() {
+    this.message_stack.push(arguments[0])
+    this.onmessage(arguments)
+  },
+  receive_message: function() {
+    this.message_stack.push(arguments[0])
+    this.onmessage(arguments)
+  },
+  open_connection: function() {
+    this.pusher.send_local_event("connection_established", { socket_id: 123 }, 'jobs')
+    this.pusher.connection = {}
+    this.pusher.connection.open = function () {
+      Pusher.log ("connection open")
+    }
+    this.pusher.connection.close = function () {
+      Pusher.log ("connection close")
+    }
+
+    this.onopen()
+  },
+  close_connection: function() {
+    this.onclose()
+  },
+}
+
+Pusher.prototype.connect = function() {
+  window.pusher_mock = new PusherMock(this)
+
+  self = this;
+
+  window.pusher_mock.onmessage = function(arguments) {
+    self.onmessage.apply(self, [ { data: arguments[0] } ]);
+  };
+  window.pusher_mock.onclose = function() {
+    self.onclose.apply(self, arguments);
+  };
+  window.pusher_mock.onopen = function() {
+    self.onopen.apply(self, arguments);
+  };
+
+}

--- a/test/views/index_mock.erb
+++ b/test/views/index_mock.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/qunit.js"></script>
+<link rel="stylesheet" href="/qunit.css">
+<script src="/jquery-1.4.2.min.js"></script>
+<script src="http://localhost:4500/dev/1.8.0/pusher.js"></script>
+<script src="/pusher_mock.js"></script>
+<script>
+var pusherKey = "key";
+Pusher.log = function(m){console.log(m)};
+</script>
+<script src="/mock_test.js"></script>
+</head>
+<body>
+  <h1 id="qunit-header">Pusher Tests</h1>
+  <h2 id="qunit-banner"></h2>
+  <h2 id="qunit-userAgent"></h2>
+  <ol id="qunit-tests"></ol>
+</body>
+</html>


### PR DESCRIPTION
Very basic mock. Proven to work with event mocks for events dispatched from server to client side. 
For now I have no use-case for the client-server messaging, so no tests provided.
Mock did not pass async test and private channel auth tests yet. But again - so far there was no test case.

Let me know if that could work for you guys. I'll continue work, if you have some interest / have ideas about how to improve that stuff.

In order to get it working with your capybaras/cucumbers, you may simply do:

```
page.evaluate_script("trigger('channel_id', 'event_name', '#{info.to_json}' )")
```

It will trigger required event by evaluating that script.
