### PR TITLE
Give event callbacks reasonable context

### DIFF
--- a/src/pusher_event_dispatcher.js
+++ b/src/pusher_event_dispatcher.js
@@ -45,7 +45,7 @@ Example:
     var callbacks = this.callbacks[event_name];
     if (callbacks) {
       for (var i = 0; i < callbacks.length; i++) {
-        callbacks[i](data);
+        callbacks[i].call(this, data);
       }
     } else if (this.failThrough) {
       this.failThrough(event_name, data)


### PR DESCRIPTION
This simple commit has callbacks executed in the context of their channels.  Please, share thoughts.

Original message:

Perhaps this is a novice question, but when handling events on a channel, how do I get the channel context?  In my particular case, the same callback methods should be able to deal with any of a set of chat windows.

The callback context used appears to be an array containing only the callback function itself, which doesn't seem so useful.   May I suggest a change to have it called back in the context of the channel, or, failing that, an optional third parameter be passable to bind? (see http://api.jquery.com/bind/)
