### PR TITLE
Error on pusher_internal:authorized callback event.

### DIFF
--- a/src/pusher_channels.js
+++ b/src/pusher_channels.js
@@ -115,7 +115,9 @@
     };
 
     channel.bind('pusher_internal:authorized', function(authorizedData) {
-      channelData = JSON.parse(authorizedData.channel_data);
+      if(authorizedData.channel_data) {
+        channelData = JSON.parse(authorizedData.channel_data);
+      }
       channel.bind("pusher_internal:subscription_succeeded", subscriptionSucceeded);
     });
 


### PR DESCRIPTION
If channel data is not sent by emitter on private and presence channels, it will break JSON.parser on null data received.

Uncaught SyntaxError: Unexpected token u
(anonymous function)
prototype.emit
(anonymous function)
xhr.onreadystatechange
