### PR TITLE
Add directive "main" to Bower manifest.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,6 @@
   "description": "Pusher JavaScript library",
   "keywords": ["pusher", "client", "publish", "subscribe", "realtime", "websocket"],
   "licence": "MIT",
-  "authors": ["Pusher <support@pusher.com>"]
+  "authors": ["Pusher <support@pusher.com>"],
+  "main": "./dist/pusher.js"
 }


### PR DESCRIPTION
As the documentation says, the "main" directive is used to specify the primary endpoints of the package.
