### PR TITLE
Better authentication failure feedback

### DIFF
--- a/dist/pusher.js
+++ b/dist/pusher.js
@@ -3632,6 +3632,7 @@
         xhr.setRequestHeader(headerName, this.authOptions.headers[headerName]);
       }
 
+      var channel = this.channel;
       xhr.onreadystatechange = function() {
         if (xhr.readyState == 4) {
           if (xhr.status == 200) {
@@ -3649,7 +3650,7 @@
             }
           } else {
             Pusher.warn("Couldn't get auth info from your webapp", xhr.status);
-            callback(true, xhr.status);
+            callback(true, {status: xhr.status, channel:channel});
           }
         }
       };

--- a/src/pusher_authorizer.js
+++ b/src/pusher_authorizer.js
@@ -45,6 +45,7 @@
         xhr.setRequestHeader(headerName, this.authOptions.headers[headerName]);
       }
 
+      var channel = this.channel;
       xhr.onreadystatechange = function() {
         if (xhr.readyState == 4) {
           if (xhr.status == 200) {
@@ -62,7 +63,7 @@
             }
           } else {
             Pusher.warn("Couldn't get auth info from your webapp", xhr.status);
-            callback(true, xhr.status);
+            callback(true, {status: xhr.status, channel:channel});
           }
         }
       };


### PR DESCRIPTION
When a channel fails to subscribe its essential to know which channel failed so you can resubsribe that channel again! This commit creates a handle to the channel which did not subscribe. 
