### PR TITLE
Update authorizer to support CSRF tokens

### DIFF
--- a/src/pusher_authorizer.js
+++ b/src/pusher_authorizer.js
@@ -41,6 +41,9 @@
 
       // add request headers
       xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+      if (self.options.csrf) {
+          xhr.setRequestHeader('X-CSRF-Token', self.options.csrf);
+      }
       for(var headerName in this.authOptions.headers) {
         xhr.setRequestHeader(headerName, this.authOptions.headers[headerName]);
       }


### PR DESCRIPTION
We use CSRF for security and I didn't see a way to make it play nice with Pusher.

So now, if you need CSRF in your authEndpoint:

```
var pusher = new Pusher('YOUR_SECRET',
        {
            csrf: $('meta[name=\'csrf-param\']').attr('content'),  // or however you normally get your token client-side...
            authEndpoint: '/_api/handshake'
        });
```

Let me know if you need anything else from me!