### PR TITLE
Allow to forgo the `new` keyword

### DIFF
--- a/src/pusher.js
+++ b/src/pusher.js
@@ -1,5 +1,9 @@
 ;(function() {
   function Pusher(app_key, options) {
+    if (!this instanceof Pusher) {
+      return new Pusher(arguments);
+    }
+
     checkAppKey(app_key);
     options = options || {};
 


### PR DESCRIPTION
Don't break in mysterious way when the user forgets to add the `new`
keyword like this:

    var pusher = Pusher("key");