### PR TITLE
Introduce simplified debug logging

### DIFF
--- a/src/pusher.js
+++ b/src/pusher.js
@@ -90,6 +90,16 @@
   Pusher.instances = [];
   Pusher.isReady = false;
 
+  Pusher.verbose = false;
+
+  if (window.console && window.console.log) {
+    Pusher.log = function(message) {
+      if (Pusher.verbose) {
+        window.console.log(message);
+      }
+    };
+  }
+
   // To receive log output provide a Pusher.log function, for example
   // Pusher.log = function(m){console.log(m)}
   Pusher.debug = function() {


### PR DESCRIPTION
This changes intends to simplify the recommended way for pusher-js
to enable logging.

The previously recommended way:

    Pusher.log = function(message) {
      if (window.console && window.console.log) {
        window.console.log(message);
      }
    };

The new recommended way:

    Pusher.verbose = true;

This change is backward-compatible. If someone installs his own logger
then `Pusher.verbose` is simply ignored.

In old IE `Pusher.verbose` is also ignored.