### PR TITLE
Document CSRF tokens in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,6 +75,17 @@ Allows passing additional data to authorizers. Supports query string params and 
       }
     });
 
+##### CSRF
+
+If you require a CSRF header for incoming requests to the private channel authentication endpoint on your server, you should add a CSRF token to the `auth` hash under `headers`. This is applicable to frameworks which apply CSRF protection by default.
+
+    var pusher = new Pusher(API_KEY, {
+      auth: {
+        params: { foo: "bar" },
+        headers: { "X-CSRF-Token": "SOME_CSRF_TOKEN" }
+      }
+    });
+
 #### `cluster` (String)
 
 Allows connecting to a different datacenter by setting up correct hostnames and ports for the connection.


### PR DESCRIPTION
We need better documentation about passing CSRF tokens through the library for auth endpoints and should encourage people not to disable CSRF protection for such routes (especially for RoR)

@zimbatm 