### PR TITLE
Introduce simplified debug logging

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0-pre
+
+[NEW] Added Pusher.logToConsole to log to console as a short-hand for writing a Pusher.log function to do so
+
 ## 3.0.0 (2015-04-23)
 
 [NEW] Introduce package.json, pusher-js will be published on NPM !

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Pusher Javascript Client
 
-This library is an open source client that allows Javascript clients to connect to the [Pusher webservice](http://pusherapp.com/). It is highly recommended that you use the hosted version of this file to stay up to date with the latest updates.
+This library is an open source client that allows Javascript web browser clients to connect to the [Pusher](http://pusher.com/) WebSocket API. It also supports fallback to HTTP connection transports. It is highly recommended that you use the hosted version of this file to stay up to date with the latest updates.
 
 We have included the source code for following libraries:
 
@@ -14,6 +14,7 @@ The following topics are covered:
 
 * Installation
 * Configuration
+* Global configuration
 * Connection
 * Socket ids
 * Subscribing to channels (public and private)
@@ -24,11 +25,15 @@ The following topics are covered:
 
 ## Installation
 
-Via the Pusher CDN (or [CDNJS](https://cdnjs.com/libraries/pusher)):
+### CDN
+
+Via the Pusher CDN:
 
 ```html
 <script src="//js.pusher.com/3.0/pusher.min.js"></script>
 ```
+
+### Bower
 
 Or via [Bower](http://bower.io/):
 
@@ -40,15 +45,29 @@ and then
 
 ```html
 <script src="bower_components/dist/pusher.min.js"></script>
+
+### NPM
+
+```
+npm install pusher-js
+```
+
+## Initialization
+
+```js
+var pusher = new Pusher(APP_KEY);
 ```
 
 ## Configuration
 
 There are a number of configuration parameters which can be set for the Pusher client, which can be passed as an object to the Pusher constructor, i.e.:
 
-    var pusher = new Pusher(API_KEY, {
-        authEndpoint: "http://example.com/pusher/auth"
-    });
+```js
+var pusher = new Pusher(APP_KEY, {
+    authEndpoint: "http://example.com/pusher/auth",
+    encrypted: true
+});
+```
 
 For most users, there is little need to change these. See [client API guide](http://pusher.com/docs/client_api_guide/client_connect) for more details.
 
@@ -132,6 +151,24 @@ After this time (in miliseconds) without any messages received from the server, 
 #### `pongTimeout` (Integer)
 
 Time before the connection is terminated after sending a ping message. Default is 30000 (30s). Low values will cause false disconnections, if latency is high.
+
+## Global configuration
+
+### `Pusher.logToConsole` (Boolean)
+
+Enables logging to the browser console via calls to `window.console.log`.
+
+### `Pusher.log` (Function)
+
+Assign a custom log handler for the Pusher library logging. For example:
+
+```js
+Pusher.log = function(msg) {
+  console.log(msg);
+};
+```
+
+By setting the `log` property you also override the use of `Pusher.enableLogging`.
 
 ## Connection
 

--- a/spec/javascripts/unit/pusher_spec.js
+++ b/spec/javascripts/unit/pusher_spec.js
@@ -1,9 +1,10 @@
 describe("Pusher", function() {
-  var _isReady, _instances;
+  var _isReady, _instances, _logToConsole;
 
   beforeEach(function() {
     _instances = Pusher.instances;
     _isReady = Pusher.isReady;
+    _logToConsole = Pusher.logToConsole;
     Pusher.isReady = false;
     Pusher.instances = [];
 
@@ -32,6 +33,43 @@ describe("Pusher", function() {
   afterEach(function() {
     Pusher.instances = _instances;
     Pusher.isReady = _isReady;
+    Pusher.logToConsole = _logToConsole;
+  });
+
+describe("Pusher.logToConsole", function() {
+    
+    var _nativeConsoleLog;
+    var _consoleLogCalls;
+    
+    beforeEach(function() {
+      _consoleLogCalls = [];
+      
+      _nativeConsoleLog = window.console.log;
+      window.console.log = function() {
+        _consoleLogCalls.push(arguments);
+      };
+    });
+    
+    afterEach(function() {
+      window.console.log = _nativeConsoleLog;
+    });
+    
+    it("should be disabled by default", function() {
+      expect(Pusher.logToConsole).toEqual(false);
+    });
+    
+    it("should not log to the console if set to false", function() {
+      var pusher = new Pusher();
+
+      expect(_consoleLogCalls.length).toEqual(0);
+    });
+    
+    it("should log to the console if set to true", function() {
+      Pusher.logToConsole = true;
+      var pusher = new Pusher();
+
+      expect(_consoleLogCalls.length).toBeGreaterThan(0);
+    });
   });
 
   describe("app key validation", function() {

--- a/src/pusher.js
+++ b/src/pusher.js
@@ -93,12 +93,12 @@
 
   Pusher.instances = [];
   Pusher.isReady = false;
-
-  Pusher.verbose = false;
+  
+  Pusher.logToConsole = false;
 
   if (window.console && window.console.log) {
     Pusher.log = function(message) {
-      if (Pusher.verbose) {
+      if (Pusher.logToConsole === true) {
         window.console.log(message);
       }
     };


### PR DESCRIPTION
Replaces #117. 

This changes intends to simplify the recommended way for pusher-js
to enable logging.

The previously recommended way:

    Pusher.log = function(message) {
      if (window.console && window.console.log) {
        window.console.log(message);
      }
    };

The new recommended way:

    Pusher.logToConsole = true;

This change is backward-compatible. If someone installs his own logger
then `Pusher.logToConsole` is simply ignored.