### PR TITLE
[[Speculative]] Abstract `window` and `document` behind a `Pusher.runtime` object

### DIFF
--- a/Jfile
+++ b/Jfile
@@ -18,7 +18,7 @@ bundle 'pusher.js' do
   license 'pusher-licence.js'
 
   file 'build/umd_header.js'
-
+  file 'runtime.js'
   file 'pusher.js'
 
   file 'utils/timers.js'

--- a/dist/sockjs.js
+++ b/dist/sockjs.js
@@ -51,7 +51,7 @@ var JSON;JSON||(JSON={}),function(){function str(a,b){var c,d,e,f,g=gap,h,i=b[a]
 //     [*] Including lib/index.js
 // Public object
 var SockJS = (function(){
-              var _document = document;
+              var _document = Pusher.runtime.getDocument();
               var _window = window;
               var utils = {};
 

--- a/spec/javascripts/unit/dependency_loader_spec.js
+++ b/spec/javascripts/unit/dependency_loader_spec.js
@@ -9,7 +9,7 @@ describe("DependencyLoader", function() {
     doc = Pusher.Mocks.getDocument();
     doc.location.protocol = "http:";
 
-    spyOn(Pusher.Util, "getDocument").andReturn(doc);
+    spyOn(Pusher.runtime, "getDocument").andReturn(doc);
     spyOn(Pusher, "ScriptRequest").andCallFake(function() {
       scriptRequest = Pusher.Mocks.getScriptRequest();
       return scriptRequest;

--- a/spec/javascripts/unit/pusher_authorizer_spec.js
+++ b/spec/javascripts/unit/pusher_authorizer_spec.js
@@ -152,7 +152,7 @@ describe("JSONP Authorizer", function() {
     document.createElement.andReturn(script);
     document.getElementsByTagName.andReturn([]);
     document.documentElement = documentElement;
-    spyOn(Pusher.Util, "getDocument").andReturn(document);
+    spyOn(Pusher.runtime, "getDocument").andReturn(document);
 
     spyOn(Pusher, "warn");
     authorizer.authorize("1.23", function() {});

--- a/spec/javascripts/unit/pusher_spec.js
+++ b/spec/javascripts/unit/pusher_spec.js
@@ -23,7 +23,7 @@ describe("Pusher", function() {
     spyOn(Pusher, "Channel").andCallFake(function(name, _) {
       return Pusher.Mocks.getChannel(name);
     });
-    spyOn(Pusher.Util, "getDocument").andReturn({
+    spyOn(Pusher.runtime, "getDocument").andReturn({
       location: {
         protocol: "http:"
       }
@@ -153,7 +153,7 @@ describe("Pusher.logToConsole", function() {
       });
 
       it("should be on when using https", function() {
-        Pusher.Util.getDocument.andReturn({
+        Pusher.runtime.getDocument.andReturn({
           location: {
             protocol: "https:"
           }
@@ -239,7 +239,7 @@ describe("Pusher.logToConsole", function() {
       });
 
       it("should be encrypted when using HTTPS", function() {
-        Pusher.Util.getDocument.andReturn({
+        Pusher.runtime.getDocument.andReturn({
           location: {
             protocol: "https:"
           }

--- a/spec/javascripts/unit/transports/transports_spec.js
+++ b/spec/javascripts/unit/transports/transports_spec.js
@@ -333,7 +333,7 @@ describe("Transports", function() {
       describe("isSupported hook", function() {
         it("should return true if window.XDomainRequest exists, document protocol is http: and connection is unencrypted", function() {
           window.XDomainRequest = function() {};
-          spyOn(Pusher.Util, "getDocument").andReturn({
+          spyOn(Pusher.runtime, "getDocument").andReturn({
             location: {
               protocol: "http:"
             }
@@ -343,7 +343,7 @@ describe("Transports", function() {
 
         it("should return true if window.XDomainRequest exists, document protocol is https: and connection is encrypted", function() {
           window.XDomainRequest = function() {};
-          spyOn(Pusher.Util, "getDocument").andReturn({
+          spyOn(Pusher.runtime, "getDocument").andReturn({
             location: {
               protocol: "https:"
             }
@@ -353,7 +353,7 @@ describe("Transports", function() {
 
         it("should return false if window.XDomainRequest exists, document protocol is http: and connection is encrypted", function() {
           window.XDomainRequest = function() {};
-          spyOn(Pusher.Util, "getDocument").andReturn({
+          spyOn(Pusher.runtime, "getDocument").andReturn({
             location: {
               protocol: "http:"
             }
@@ -363,7 +363,7 @@ describe("Transports", function() {
 
         it("should return false if window.XDomainRequest exists, document protocol is https: and connection is unencrypted", function() {
           window.XDomainRequest = function() {};
-          spyOn(Pusher.Util, "getDocument").andReturn({
+          spyOn(Pusher.runtime, "getDocument").andReturn({
             location: {
               protocol: "https:"
             }

--- a/spec/karma/files/source.js
+++ b/spec/karma/files/source.js
@@ -1,4 +1,5 @@
 module.exports = [
+  'src/runtime.js',
   'src/pusher.js',
 
   'src/utils/timers.js',

--- a/src/base64.js
+++ b/src/base64.js
@@ -43,7 +43,7 @@
     return chars.join('');
   };
 
-  var btoa = window.btoa || function(b) {
+  var btoa = Pusher.runtime.getWindow().btoa || function(b) {
     return b.replace(/[\s\S]{1,3}/g, cb_encode);
   };
 

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -16,7 +16,7 @@
 
   // Allows calling a function when the document body is available
    function onDocumentBody(callback) {
-    if (document.body) {
+    if (Pusher.runtime.getDocument().body) {
       callback();
     } else {
       setTimeout(function() {
@@ -29,9 +29,13 @@
     onDocumentBody(initialize);
   }
 
-  if (!window.JSON) {
+  if (typeof(Pusher.runtime.getWindow().JSON)=== undefined) {
     Pusher.Dependencies.load("json2", {}, initializeOnDocumentBody);
   } else {
-    initializeOnDocumentBody();
+    if (Pusher.runtime instanceof _PusherRuntimes.Browser){
+      initializeOnDocumentBody();
+    } else {
+      initialize();
+    }
   }
 })();

--- a/src/dependency_loader.js
+++ b/src/dependency_loader.js
@@ -62,7 +62,7 @@
    */
   prototype.getRoot = function(options) {
     var cdn;
-    var protocol = Pusher.Util.getDocument().location.protocol;
+    var protocol = Pusher.runtime.getDocument().location.protocol;
     if ((options && options.encrypted) || protocol === "https:") {
       cdn = this.options.cdn_https;
     } else {

--- a/src/dom/script_request.js
+++ b/src/dom/script_request.js
@@ -13,6 +13,8 @@
   }
   var prototype = ScriptRequest.prototype;
 
+  var _document = Pusher.runtime.getDocument();
+
   /** Sends the actual script request.
    *
    * @param {ScriptReceiver} receiver
@@ -21,7 +23,7 @@
     var self = this;
     var errorString = "Error loading " + self.src;
 
-    self.script = document.createElement("script");
+    self.script = _document.createElement("script");
     self.script.id = receiver.id;
     self.script.src = self.src;
     self.script.type = "text/javascript";
@@ -44,9 +46,9 @@
     }
 
     // Opera<11.6 hack for missing onerror callback
-    if (self.script.async === undefined && document.attachEvent &&
+    if (self.script.async === undefined && _document.attachEvent &&
         /opera/i.test(navigator.userAgent)) {
-      self.errorScript = document.createElement("script");
+      self.errorScript = _document.createElement("script");
       self.errorScript.id = receiver.id + "_error";
       self.errorScript.text = receiver.name + "('" + errorString + "');";
       self.script.async = self.errorScript.async = false;
@@ -54,7 +56,7 @@
       self.script.async = true;
     }
 
-    var head = document.getElementsByTagName('head')[0];
+    var head = _document.getElementsByTagName('head')[0];
     head.insertBefore(self.script, head.firstChild);
     if (self.errorScript) {
       head.insertBefore(self.errorScript, self.script.nextSibling);

--- a/src/events_dispatcher.js
+++ b/src/events_dispatcher.js
@@ -1,4 +1,5 @@
 ;(function() {
+  var _window = Pusher.runtime.getWindow();
   /** Manages callback bindings and event emitting.
    *
    * @param Function failThrough called when no listeners are bound to an event
@@ -40,7 +41,7 @@
     var callbacks = this.callbacks.get(eventName);
     if (callbacks && callbacks.length > 0) {
       for (i = 0; i < callbacks.length; i++) {
-        callbacks[i].fn.call(callbacks[i].context || window, data);
+        callbacks[i].fn.call(callbacks[i].context || _window, data);
       }
     } else if (this.failThrough) {
       this.failThrough(eventName, data);

--- a/src/net_info.js
+++ b/src/net_info.js
@@ -5,16 +5,19 @@
    * - online - when browser goes online
    * - offline - when browser goes offline
    */
+
+  var _window = Pusher.runtime.getWindow();
+
   function NetInfo() {
     Pusher.EventsDispatcher.call(this);
 
     var self = this;
     // This is okay, as IE doesn't support this stuff anyway.
-    if (window.addEventListener !== undefined) {
-      window.addEventListener("online", function() {
+    if (_window.addEventListener !== undefined) {
+      _window.addEventListener("online", function() {
         self.emit('online');
       }, false);
-      window.addEventListener("offline", function() {
+      _window.addEventListener("offline", function() {
         self.emit('offline');
       }, false);
     }
@@ -32,10 +35,10 @@
    * @return {Boolean}
    */
   prototype.isOnline = function() {
-    if (window.navigator.onLine === undefined) {
+    if (_window.navigator.onLine === undefined) {
       return true;
     } else {
-      return window.navigator.onLine;
+      return _window.navigator.onLine;
     }
   };
 

--- a/src/pusher.js
+++ b/src/pusher.js
@@ -89,6 +89,13 @@
       self.connect();
     }
   }
+
+  if (typeof(Window) !== 'undefined' && this instanceof Window && !!this.document){
+    Pusher.runtime = new _PusherRuntimes.Browser(this);
+  } else {
+    Pusher.runtime = new _PusherRuntimes.NonBrowser(this);
+  }
+
   var prototype = Pusher.prototype;
 
   Pusher.instances = [];
@@ -96,10 +103,12 @@
   
   Pusher.logToConsole = false;
 
-  if (window.console && window.console.log) {
+  var _window = Pusher.runtime.getWindow();
+
+  if (_window.console && _window.console.log) {
     Pusher.log = function(message) {
       if (Pusher.logToConsole === true) {
-        window.console.log(message);
+        _window.console.log(message);
       }
     };
   }
@@ -115,11 +124,11 @@
 
   Pusher.warn = function() {
     var message = Pusher.Util.stringify.apply(this, arguments);
-    if (window.console) {
-      if (window.console.warn) {
-        window.console.warn(message);
-      } else if (window.console.log) {
-        window.console.log(message);
+    if (_window.console) {
+      if (_window.console.warn) {
+        _window.console.warn(message);
+      } else if (_window.console.log) {
+        _window.console.log(message);
       }
     }
     if (Pusher.log) {
@@ -204,7 +213,7 @@
   };
 
   prototype.isEncrypted = function() {
-    if (Pusher.Util.getDocument().location.protocol === "https:") {
+    if (Pusher.runtime.getDocument().location.protocol === "https:") {
       return true;
     } else {
       return Boolean(this.config.encrypted);

--- a/src/pusher_authorizer.js
+++ b/src/pusher_authorizer.js
@@ -79,7 +79,7 @@
       var callbackName = nextAuthCallbackID.toString();
       nextAuthCallbackID++;
 
-      var document = Pusher.Util.getDocument();
+      var document = Pusher.runtime.getDocument();
       var script = document.createElement("script");
       // Hacked wrapper.
       Pusher.auth_callbacks[callbackName] = function(data) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,0 +1,38 @@
+;(function(){
+
+  function Runtime(context){
+    this.context = context;
+  };
+
+  function BrowserRuntime(context){
+    this.context = context;
+  }
+
+  function NonBrowserRuntime(context){
+    this.context = context;
+  }
+
+  Runtime.prototype.getWindow = function() {
+    return this.context;
+  };
+
+  BrowserRuntime.prototype = new Runtime();
+  BrowserRuntime.prototype.constructor = BrowserRuntime;
+
+  BrowserRuntime.prototype.getDocument = function(){
+    return this.context.document;
+  }
+
+  NonBrowserRuntime.prototype = new Runtime();
+  NonBrowserRuntime.prototype.constructor = NonBrowserRuntime;
+
+  NonBrowserRuntime.prototype.getDocument = function(){
+    return this.context;
+  }
+
+  this._PusherRuntimes = {
+    Browser: BrowserRuntime,
+    NonBrowser: NonBrowserRuntime
+  }
+
+}).call(this);

--- a/src/transports/transports.js
+++ b/src/transports/transports.js
@@ -1,4 +1,6 @@
 (function() {
+  var _window = Pusher.runtime.getWindow();
+
   /** WebSocket transport.
    *
    * Uses native WebSocket implementation, including MozWebSocket supported by
@@ -10,13 +12,13 @@
     supportsPing: false,
 
     isInitialized: function() {
-      return Boolean(window.WebSocket || window.MozWebSocket);
+      return Boolean(_window.WebSocket || _window.MozWebSocket);
     },
     isSupported: function() {
-      return Boolean(window.WebSocket || window.MozWebSocket);
+      return Boolean(_window.WebSocket || _window.MozWebSocket);
     },
     getSocket: function(url) {
-      var Constructor = window.WebSocket || window.MozWebSocket;
+      var Constructor = _window.WebSocket || _window.MozWebSocket;
       return new Constructor(url);
     }
   });
@@ -32,7 +34,7 @@
       return true;
     },
     isInitialized: function() {
-      return window.SockJS !== undefined;
+      return _window.SockJS !== undefined;
     },
     getSocket: function(url, options) {
       return new SockJS(url, null, {

--- a/src/util.js
+++ b/src/util.js
@@ -49,7 +49,7 @@
         if (typeof arguments[i] === "string") {
           m.push(arguments[i]);
         } else {
-          if (window.JSON === undefined) {
+          if (Pusher.runtime.getWindow().JSON === undefined) {
             m.push(arguments[i].toString());
           } else {
             m.push(JSON.stringify(arguments[i]));
@@ -131,7 +131,7 @@
      */
     apply: function(array, f, context) {
       for (var i = 0; i < array.length; i++) {
-        f.call(context || window, array[i], i, array);
+        f.call(context || Pusher.runtime.getWindow(), array[i], i, array);
       }
     },
 
@@ -283,17 +283,9 @@
       };
     },
 
-    getWindow: function() {
-      return window;
-    },
-
-    getDocument: function() {
-      return document;
-    },
-
     getLocalStorage: function() {
       try {
-        return window.localStorage;
+        return Pusher.runtime.getWindow().localStorage;
       } catch (e) {
         return undefined;
       }
@@ -318,7 +310,7 @@
     },
 
     removeWindowListener: function(event, listener) {
-      var _window = Pusher.Util.getWindow();
+      var _window = Pusher.runtime.getWindow();
       if (_window.addEventListener !== undefined) {
         _window.removeEventListener(event, listener, false);
       } else {
@@ -327,14 +319,14 @@
     },
 
     isXHRSupported: function() {
-      var XHR = window.XMLHttpRequest;
+      var XHR = Pusher.runtime.getWindow().XMLHttpRequest;
       return Boolean(XHR) && (new XHR()).withCredentials !== undefined;
     },
 
     isXDRSupported: function(encrypted) {
       var protocol = encrypted ? "https:" : "http:";
-      var documentProtocol = Pusher.Util.getDocument().location.protocol;
-      return Boolean(window.XDomainRequest) && documentProtocol === protocol;
+      var documentProtocol = Pusher.runtime.getDocument().location.protocol;
+      return Boolean(Pusher.runtime.getWindow().XDomainRequest) && documentProtocol === protocol;
     }
   };
 }).call(this);

--- a/src/utils/timers.js
+++ b/src/utils/timers.js
@@ -1,10 +1,13 @@
 ;(function() {
+
+  var _window = Pusher.runtime.getWindow();
+
   // We need to bind clear functions this way to avoid exceptions on IE8
   function clearTimeout(timer) {
-    window.clearTimeout(timer);
+    _window.clearTimeout(timer);
   }
   function clearInterval(timer) {
-    window.clearInterval(timer);
+    _window.clearInterval(timer);
   }
 
   function GenericTimer(set, clear, delay, callback) {


### PR DESCRIPTION
Still untidy and a work in progress and is meant to be a piece for discussion rather than anything else. It came about when I tried to get PusherJS working for ReactNative, but the ReactNative runtime does not have a `document`. @leggetter recommended I try to get PusherJS working in a WebWorker to test things out. WebWorkers, similarly, do not have a `document`, nor does it have a `window`.

This basically detects the runtime environment, i.e. `Browser` or `NonBrowser`. Each `runtime` has `getWindow` and `getDocument` method. I've replaced all direct references to `window` and `document` to `Pusher.runtime.getWindow()` and `Pusher.runtime.getDocument()` respectively. As a result, the library can supply an appropriate value for `window` and `document` based on the environment.

At the moment this is _very_ hacky. There's no appropriate "mock" for `getDocument ` in a non-browser environment - still trying to think about that. PusherJS works in a WebWorker with these changes, and the following code:

```js
importScripts("pusher.js");

var pusher = new Pusher('app_key', {
  disableStats: true
});

var channel = pusher.subscribe('test_channel');

channel.bind('my_event', function(data) {
  postMessage(data); // send the data to the application thread
});
```

WDYT @pl @leggetter @zimbatm ? Is it at least the right start?