### PR TITLE
Throw when app_id is not specified

### DIFF
--- a/src/pusher.js
+++ b/src/pusher.js
@@ -213,9 +213,7 @@
 
   function checkAppKey(key) {
     if (key === null || key === undefined) {
-      Pusher.warn(
-        'Warning', 'You must pass your app key when you instantiate Pusher.'
-      );
+      throw 'You must pass your app key when you instantiate Pusher.';
     }
   }
 


### PR DESCRIPTION
Warnings are too easily ignored, and this one will definitely become an
error once we try to connect, so there's no point continuing