### PR TITLE
Pattern matching on event names. Resolves #135

### DIFF
--- a/src/events_dispatcher.js
+++ b/src/events_dispatcher.js
@@ -20,6 +20,19 @@
     return this;
   };
 
+  prototype.bind_pattern = function(pattern, userCallback){
+    if (!(pattern instanceof(RegExp))) {
+      Pusher.warn("::bind_pattern expects a RegExp");
+      return;
+    }
+    var callback = function(eventName, data){
+      if (pattern.test(eventName)) {
+        userCallback(data, eventName);
+      }
+    };
+    this.bind_all(callback);
+  };
+
   prototype.unbind = function(eventName, callback, context) {
     this.callbacks.remove(eventName, callback, context);
     return this;


### PR DESCRIPTION
Allows you to pass an event pattern to a `bind_pattern` method.

```js
channel.bind_pattern(/events-/, function(data, match) {
  console.log("MESSAGE!!", data, match);
});
```

Rather than playing around with the plumbing, it just wraps around the `bind_all` method, like customers do already

cc @zimbatm @jackfranklin 