### PR TITLE
POC: add ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm: 2.0.0
+before_script:
+  - bundle install
+  - npm install
+script:
+  - ./bin/karma-unit

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   "devDependencies": {
     "jshint": "~2.6.3",
     "karma": "~0.12.0",
-    "karma-jasmine": "~0.1.0",
+    "karma-browserstack-launcher": "^0.1.10",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",
     "karma-firefox-launcher": "^0.1.4",
+    "karma-jasmine": "~0.1.0",
     "karma-opera-launcher": "^0.1.0",
     "karma-safari-launcher": "^0.1.1"
   }

--- a/spec/karma/config/unit.js
+++ b/spec/karma/config/unit.js
@@ -28,7 +28,36 @@ module.exports = function(config) {
 
     autoWatch: true,
 
-    browsers: ['Chrome', 'Firefox', 'Opera', 'Safari'],
+    // for dev testing
+    // browsers: ['Chrome', 'Firefox', 'Opera', 'Safari'],
+
+    browserStack: {
+      startTunnel: true
+    },
+    customLaunchers: {
+      bs_ie8: {
+        base: 'BrowserStack',
+        browser: 'ie',
+        browser_version: '8.0',
+        os: "Windows",
+        os_version: '7'
+      },
+      bs_firefox_mac: {
+        base: 'BrowserStack',
+        browser: 'firefox',
+        browser_version: '21.0',
+        os: 'OS X',
+        os_version: 'Mountain Lion'
+      },
+      bs_iphone5: {
+        base: 'BrowserStack',
+        device: 'iPhone 5',
+        os: 'ios',
+        os_version: '6.0'
+      }
+    },
+
+    browsers: ['bs_ie8', 'bs_firefox_mac', 'bs_iphone5'],
     captureTimeout: 60000,
 
     singleRun: true


### PR DESCRIPTION
Using browserstack on travis to CI test a number of browsers.

Todo:

- [ ] Add for integration tests
- [ ] Get a list of troublesome browsers and add those to the config