### PR TITLE
Make `warn` check for `Pusher.log` first

### DIFF
--- a/src/pusher.js
+++ b/src/pusher.js
@@ -115,15 +115,14 @@
 
   Pusher.warn = function() {
     var message = Pusher.Util.stringify.apply(this, arguments);
-    if (window.console) {
+    if (Pusher.log) {
+      Pusher.log(message);
+    } else if (window.console) {
       if (window.console.warn) {
         window.console.warn(message);
       } else if (window.console.log) {
         window.console.log(message);
       }
-    }
-    if (Pusher.log) {
-      Pusher.log(message);
     }
   };
 


### PR DESCRIPTION
This fixes Issue #148 which notes that `Pusher.warn` logs twice if
you've got `Pusher.log` defined. Now we first check for `Pusher.log` and
use that before logging directly to console.