### PR TITLE
Subscription unsubscription robustification

### DIFF
--- a/spec/javascripts/helpers/mocks.js
+++ b/spec/javascripts/helpers/mocks.js
@@ -232,6 +232,7 @@ var Mocks = {
     channel.cancelSubscription = jasmine.createSpy("cancelSubscription");
     channel.disconnect = jasmine.createSpy("disconnect");
     channel.handleEvent = jasmine.createSpy("handleEvent");
+    channel.reinstateSubscription = jasmine.createSpy("reinstateSubscription");
     channel.subscribe = jasmine.createSpy("subscribe");
     channel.unsubscribe = jasmine.createSpy("unsubscribe");
     return channel;

--- a/spec/javascripts/integration/core/pusher_spec.js
+++ b/spec/javascripts/integration/core/pusher_spec.js
@@ -200,6 +200,197 @@ Integration.describe("Pusher", function() {
     });
   }
 
+  function buildSubscriptionStateTests(getPusher, prefix) {
+    it("sub-sub = sub", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      waitsFor(function() {
+        return pusher.channel(channelName).subscribed;
+      }, "subscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      });
+    });
+
+    it("sub-wait-sub = sub", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      waitsFor(function() {
+        return pusher.channel(channelName).subscribed;
+      }, "subscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+        pusher.subscribe(channelName)
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      });
+    });
+
+    it("sub-unsub = NOP", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      pusher.unsubscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(true);
+
+      waitsFor(function() {
+        return !pusher.channel(channelName);
+      }, "unsubscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName)).toBe(undefined);
+      });
+    });
+
+    it("sub-wait-unsub = NOP", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      waitsFor(function() {
+        return pusher.channel(channelName).subscribed;
+      }, "subscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+        pusher.unsubscribe(channelName)
+        expect(pusher.channel(channelName)).toBe(undefined);
+      });
+    });
+
+    it("sub-unsub-sub = sub", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      pusher.unsubscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(true);
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      waitsFor(function() {
+        return pusher.channel(channelName).subscribed;
+      }, "subscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      });
+    });
+
+    it("sub-unsub-wait-sub = sub", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      pusher.unsubscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(true);
+
+      waitsFor(function() {
+        return !pusher.channel(channelName);
+      }, "unsubscription to finish", 10000);
+      runs(function() {
+        expect(pusher.channel(channelName)).toBe(undefined);
+
+        pusher.subscribe(channelName)
+        expect(pusher.channel(channelName).subscribed).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      });
+
+      waitsFor(function() {
+        return pusher.channel(channelName).subscribed;
+      }, "subscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName).subscribed).toEqual(true);
+        expect(pusher.channel(channelName).subscriptionPending).toEqual(false);
+        expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+      });
+    });
+
+    it("sub-unsub-unsub = NOP", function() {
+      var pusher = getPusher();
+      var channelName = Integration.getRandomName((prefix || "") + "integration");
+
+      pusher.subscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(false);
+
+      pusher.unsubscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(true);
+
+      pusher.unsubscribe(channelName)
+      expect(pusher.channel(channelName).subscribed).toEqual(false);
+      expect(pusher.channel(channelName).subscriptionPending).toEqual(true);
+      expect(pusher.channel(channelName).subscriptionCancelled).toEqual(true);
+
+      waitsFor(function() {
+        return !pusher.channel(channelName);
+      }, "unsubscription to finish", 10000);
+
+      runs(function() {
+        expect(pusher.channel(channelName)).toBe(undefined);
+      });
+    });
+  }
 
   function buildClientEventsTests(getPusher1, getPusher2, prefix) {
     it("should receive a client event sent by another connection", function() {
@@ -532,6 +723,12 @@ Integration.describe("Pusher", function() {
         buildPublicChannelTests(
           function() { return pusher1; }
         );
+
+        buildSubscriptionStateTests(
+          function() { return pusher1; },
+          "private-"
+        );
+
         if (canRunTwoConnections(transport, encrypted)) {
           buildClientEventsTests(
             function() { return pusher1; },
@@ -545,6 +742,12 @@ Integration.describe("Pusher", function() {
         buildPublicChannelTests(
           function() { return pusher1; }
         );
+
+        buildSubscriptionStateTests(
+          function() { return pusher1; },
+          "presence-"
+        );
+
         if (canRunTwoConnections(transport, encrypted)) {
           buildClientEventsTests(
             function() { return pusher1; },

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -218,7 +218,7 @@ describe("Channel", function() {
       channel.subscribe();
 
       expect(channel.subscriptionPending).toEqual(false);
-    }
+    });
   });
 
   describe("#unsubscribe", function() {

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -241,4 +241,15 @@ describe("Channel", function() {
       expect(channel.subscriptionCancelled).toEqual(true);
     });
   });
+
+  describe("#reinstateSubscription", function() {
+    it("should set #subscriptionCancelled to false", function() {
+      channel.cancelSubscription()
+      expect(channel.subscriptionCancelled).toEqual(true);
+
+      channel.reinstateSubscription();
+
+      expect(channel.subscriptionCancelled).toEqual(false);
+    });
+  });
 });

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -204,13 +204,21 @@ describe("Channel", function() {
       expect(pusher.send_event).not.toHaveBeenCalled();
     });
 
-    it("should set #subscriptionPending to true", function() {
+    it("should set #subscriptionPending to true if previously unsubscribed", function() {
       expect(channel.subscriptionPending).toEqual(false);
 
       channel.subscribe();
 
       expect(channel.subscriptionPending).toEqual(true);
     });
+
+    it("should do nothing if already subscribed", function() {
+      channel.subscribed = true;
+
+      channel.subscribe();
+
+      expect(channel.subscriptionPending).toEqual(false);
+    }
   });
 
   describe("#unsubscribe", function() {

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -307,6 +307,15 @@ describe("Pusher", function() {
         var channel = pusher.subscribe("xxx");
         expect(channel.subscribe).toHaveBeenCalled();
       });
+
+      it("should reinstate cancelled pending subscription", function() {
+        var channel = pusher.subscribe("xxx");
+        channel.subscriptionPending = true;
+        channel.subscriptionCancelled = true;
+        pusher.subscribe("xxx");
+
+        expect(channel.reinstateSubscription).toHaveBeenCalled();
+      })
     });
 
     describe("#unsubscribe", function() {

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -77,7 +77,9 @@ export default class Channel extends EventsDispatcher {
 
   /** Sends a subscription request. For internal use only. */
   subscribe() {
+    if (this.subscribed) { return; }
     this.subscriptionPending = true;
+    this.subscriptionCancelled = false;
     this.authorize(this.pusher.connection.socket_id, (error, data)=> {
       if (error) {
         this.handleEvent('pusher:subscription_error', data);
@@ -102,5 +104,10 @@ export default class Channel extends EventsDispatcher {
   /** Cancels an in progress subscription. For internal use only. */
   cancelSubscription() {
     this.subscriptionCancelled = true;
+  }
+
+  /** Reinstates an in progress subscripiton. For internal use only. */
+  reinstateSubscription() {
+    this.subscriptionCancelled = false;
   }
 }

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -206,7 +206,9 @@ export default class Pusher {
 
   subscribe(channel_name : string) {
     var channel = this.channels.add(channel_name, this);
-    if (this.connection.state === "connected") {
+    if (channel.subscriptionPending && channel.subscriptionCancelled) {
+      channel.reinstateSubscription();
+    } else if (!channel.subscriptionPending && this.connection.state === "connected") {
       channel.subscribe();
     }
     return channel;


### PR DESCRIPTION
Following on from the discussion in #196, adds a method to reinstate a cancelled subscription. We should now be able to handle arbitrary chains of subscriptions and unsubscriptions – where the final method is always respected – regardless of the timings.

e.g. subscribe -> unsubscribe -> subscribe -> subscribe -> unsubscribe -> subscribe = subscribe

@hph 