### PR TITLE
Prod 1211 unbind all

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.0.0 (2016-12-01)
+
+New major version released due to breaking changes:
+
+[CHANGED] rename bind_all to bind_global
+
+[NEW] unbind_global to remove global bindings
+
+[CHANGED] unbind_all now removes global bindings as well as event specific
+
+[NEW] expose context to pusher level bindings
+
 ## 3.2.4 (2016-10-29)
 
 [FIXED] Subscriptions are reinstated correctly after a disconnection and

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,7 +2,7 @@
 
 ## 4.0.0 (2016-12-01)
 
-New major version released due to breaking changes:
+New major version released due to breaking changes.
 
 [CHANGED] rename bind_all to bind_global
 

--- a/README.markdown
+++ b/README.markdown
@@ -300,83 +300,68 @@ socket.unsubscribe('private-my-channel');
 
 ## Binding to events
 
-Events can be bound to at 2 levels, the global, and per channel. They take a very similar form to the way events are handled in jQuery.
+Event binding takes a very similar form to the way events are handled in jQuery. You can use the following methods either on a channel object, to bind to events on a particular channel; or on the pusher object, to bind to events on all subscribed channels simultaneously.
 
-### Global events
-
-You can attach behaviour to these events regardless of the channel the event is broadcast to. The following is an example of an app that binds to new comments from any channel:
-
+### `bind` and `unbind`
+Binding to "new-message" on channel: The following logs message data to the console when "new-message" is received
 ```js
-var socket = new Pusher('MY_API_KEY');
-var my_channel = socket.subscribe('my-channel');
-socket.bind('new-comment',
-  function(data) {
-    // add comment into page
-  }
-);
-```
-
-### Per-channel events
-
-These are bound to a specific channel, and mean that you can reuse event names in different parts of your client application. The following might be an example of a stock tracking app where several channels are opened for different companies:
-
-```js
-var socket = new Pusher('MY_API_KEY');
-var channel = socket.subscribe('APPL');
-channel.bind('new-price',
-  function(data) {
-    // add new price into the APPL widget
-  }
-);
-```
-
-### Bind event handler with optional context
-
-It is possible to provide a third, optional parameter that is used as the `this` value when calling a handler:
-
-```js
-var context = { title: 'Pusher' };
-var handler = function(){
-  console.log('My name is ' + this.title);
-};
-channel.bind('new-comment', handler, context);
-```
-
-### Unbind event handlers
-
-Remove previously-bound handlers from an object. Only handlers that match all of the provided arguments (`eventName`, `handler` or `context`) are removed:
-
-```js
-channel.unbind('new-comment', handler); // removes just `handler` for the `new-comment` event
-channel.unbind('new-comment'); // removes all handlers for the `new-comment` event
-channel.unbind(null, handler); // removes `handler` for all events
-channel.unbind(null, null, context); // removes all handlers for `context`
-channel.unbind(); // removes all handlers on `channel`
-```
-
-### Binding to everything
-
-It is possible to bind to all events, rather than specifying the event name, using the method `bind_all`. This can be used for debugging, but may have other utilities.
-
-This binding can be done for a single channel or for all subscribed channels. Here is how to bind to all events on a single channel:
-
-```javascript
-var channel = pusher.subscribe('test_channel');
-channel.bind_all(function(eventName, data) {
-  console.log("Received event on channel test_channel event with name", eventName, "and data", data);
+channel.bind("new-message", function (data) {
+  console.log(data.message);
 });
 ```
 
-To bind to all events on all subscribed channels, instead call `pusher.bind_all`:
+We can also provide the `this` value when calling a handler as a third optional parameter. The following logs "hi Pusher" when "my-event" is fired.
 
-```javascript
-pusher.bind_all(function(eventName, data) {
-  console.log("Received event with name", eventName, "and data", data);
-});
+```js
+channel.bind(
+  "my-event",
+  function () { console.log("hi " + this.name); },
+  { name: "Pusher" }
+);
 ```
 
-(Note that this will only work if the event is sent on a subscribed channel. Also note that this does not tell your callback which subscribed channel the event was sent on.)
+Unsubscribe behaviour varies depending on which parameters you provide it with. For example:
 
+```js
+// remove just `handler` for the `new-comment` event
+channel.unbind("new-comment", handler);
+
+// remove all handlers for the `new-comment` event
+channel.unbind("new-comment");
+
+// remove `handler` for all events
+channel.unbind(null, handler);
+
+// remove all handlers for `context`
+channel.unbind(null, null, context);
+
+// remove all handlers on `channel`
+channel.unbind();
+```
+
+### `bind_global` and `unbind_global`
+
+`bind_global` and `unbind_global` work much like `bind` and `unbind`, but instead of only firing callbacks on a specific event, they fire callbacks on any event, and provide that event along to the handler along with the event data. For example:
+
+```js
+channel.bind_global(function (event, data) {
+  console.log("The event " + event + " was triggered with data " + data);
+})
+```
+
+`unbind_global` works similarly to `unbind`.
+
+```js
+// remove just `handler` from global bindings
+channel.unbind_global(handler);
+
+// remove all global bindings
+channel.unbind_global();
+```
+
+### `unbind_all`
+
+The `unbind_all` method is equivalent to calling `unbind()` and `unbind_global()` together; it removes all bindings, global and event specific.
 
 ## Batching auth requests (aka multi-auth)
 

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -70,7 +70,7 @@ describe("Channel", function() {
     it("should not emit pusher_internal:* events", function() {
       var callback = jasmine.createSpy("callback");
       channel.bind("pusher_internal:test", callback);
-      channel.bind_all(callback);
+      channel.bind_global(callback);
 
       channel.handleEvent("pusher_internal:test");
 

--- a/spec/javascripts/unit/core/channels/presence_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/presence_channel_spec.js
@@ -129,7 +129,7 @@ describe("PresenceChannel", function() {
       it("should not emit pusher_internal:* events", function() {
         var callback = jasmine.createSpy("callback");
         channel.bind("pusher_internal:test", callback);
-        channel.bind_all(callback);
+        channel.bind_global(callback);
 
         channel.handleEvent("pusher_internal:test");
 

--- a/spec/javascripts/unit/core/channels/private_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/private_channel_spec.js
@@ -91,7 +91,7 @@ describe("PrivateChannel", function() {
     it("should not emit pusher_internal:* events", function() {
       var callback = jasmine.createSpy("callback");
       channel.bind("pusher_internal:test", callback);
-      channel.bind_all(callback);
+      channel.bind_global(callback);
 
       channel.handleEvent("pusher_internal:test");
 

--- a/spec/javascripts/unit/core/events_dispatcher_spec.js
+++ b/spec/javascripts/unit/core/events_dispatcher_spec.js
@@ -44,11 +44,11 @@ describe("EventsDispatcher", function() {
     });
   });
 
-  describe("#bind_all", function() {
+  describe("#bind_global", function() {
     it("should add the listener to all events", function() {
       var onAll = jasmine.createSpy("onAll");
 
-      dispatcher.bind_all(onAll);
+      dispatcher.bind_global(onAll);
       dispatcher.emit("event", "test");
       dispatcher.emit("boop", []);
 
@@ -256,7 +256,7 @@ describe("EventsDispatcher", function() {
         return jasmine.createSpy("onGlobal" + i);
       });
       Collections.apply(callbacks, function(callback) {
-        dispatcher.bind_all(callback);
+        dispatcher.bind_global(callback);
       });
 
       dispatcher.emit("g", { y: 2 });
@@ -305,6 +305,73 @@ describe("EventsDispatcher", function() {
 
       expect(boundContext).toEqual(context);
       expect(unboundContext).toEqual(global);
+    });
+  });
+
+  describe("#unbind_global", function() {
+    it("should remove a particular global callback if specified", function () {
+      var global1 = jasmine.createSpy("global1");
+      var global2 = jasmine.createSpy("global2");
+
+      dispatcher.bind_global(global1);
+      dispatcher.bind_global(global2);
+
+      dispatcher.unbind_global(global1);
+
+      dispatcher.emit("event", "test");
+
+      expect(global1).not.toHaveBeenCalled();
+      expect(global2).toHaveBeenCalledWith("event", "test");
+    });
+
+    it("should remove all global callbacks if called with no params", function () {
+      var global1 = jasmine.createSpy("global1");
+      var global2 = jasmine.createSpy("global2");
+
+      dispatcher.bind_global(global1);
+      dispatcher.bind_global(global2);
+
+      dispatcher.unbind_global();
+
+      dispatcher.emit("event", "test");
+
+      expect(global1).not.toHaveBeenCalled();
+      expect(global2).not.toHaveBeenCalled();
+    });
+
+    it("should not remove any event specific callbacks", function () {
+      var specific = jasmine.createSpy("specific");
+
+      dispatcher.bind("event", specific);
+
+      dispatcher.unbind_global();
+
+      dispatcher.emit("event", "test");
+
+      expect(specific).toHaveBeenCalledWith("test");
+    });
+  });
+
+  describe("#unbind_all", function () {
+    it("should remove all bindings – global and event specific", function () {
+      var global1 = jasmine.createSpy("global1");
+      var global2 = jasmine.createSpy("global2");
+      var specific1 = jasmine.createSpy("specific1");
+      var specific2 = jasmine.createSpy("specific2");
+
+      dispatcher.bind_global(global1);
+      dispatcher.bind_global(global2);
+      dispatcher.bind("event", specific1);
+      dispatcher.bind("event", specific2);
+
+      dispatcher.unbind_all();
+
+      dispatcher.emit("event", "test");
+
+      expect(global1).not.toHaveBeenCalled();
+      expect(global2).not.toHaveBeenCalled();
+      expect(specific1).not.toHaveBeenCalled();
+      expect(specific2).not.toHaveBeenCalled();
     });
   });
 });

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -396,7 +396,7 @@ describe("Pusher", function() {
       var onEvent = jasmine.createSpy("onEvent");
       var onAllEvents = jasmine.createSpy("onAllEvents");
       pusher.bind("global", onEvent);
-      pusher.bind_all(onAllEvents);
+      pusher.bind_global(onAllEvents);
 
       pusher.connection.emit("message", {
         event: "global",

--- a/src/core/events/dispatcher.ts
+++ b/src/core/events/dispatcher.ts
@@ -1,5 +1,6 @@
-import CallbackRegistry from './callback_registry';
+import * as Collections from '../utils/collections';
 import Callback from './callback';
+import CallbackRegistry from './callback_registry';
 
 /** Manages callback bindings and event emitting.
  *
@@ -21,18 +22,33 @@ export default class Dispatcher {
     return this;
   }
 
-  bind_all(callback : Function) {
+  bind_global(callback : Function) {
     this.global_callbacks.push(callback);
     return this;
   }
 
-  unbind(eventName : string, callback : Function, context?: any) {
+  unbind(eventName? : string, callback? : Function, context?: any) {
     this.callbacks.remove(eventName, callback, context);
     return this;
   }
 
-  unbind_all(eventName?: string, callback?: Function) {
-    this.callbacks.remove(eventName, callback);
+  unbind_global(callback?: Function) {
+    if (!callback) {
+      this.global_callbacks = [];
+      return this;
+    }
+
+    this.global_callbacks = Collections.filter(
+      this.global_callbacks || [],
+      c => c !== callback
+    );
+
+    return this;
+  }
+
+  unbind_all() {
+    this.unbind();
+    this.unbind_global();
     return this;
   }
 

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -183,12 +183,12 @@ export default class Pusher {
     }
   }
 
-  bind(event_name : string, callback : Function) : Pusher {
-    this.global_emitter.bind(event_name, callback);
+  bind(event_name : string, callback : Function, context? : any) : Pusher {
+    this.global_emitter.bind(event_name, callback, context);
     return this;
   }
 
-  unbind(event_name?: string, callback?: Function) : Pusher {
+  unbind(event_name? : string, callback? : Function, context? : any) : Pusher {
     this.global_emitter.unbind(event_name, callback);
     return this;
   }

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -188,13 +188,23 @@ export default class Pusher {
     return this;
   }
 
-  unbind(event_name: string, callback: Function) : Pusher {
+  unbind(event_name?: string, callback?: Function) : Pusher {
     this.global_emitter.unbind(event_name, callback);
     return this;
   }
 
   bind_global(callback : Function) : Pusher {
     this.global_emitter.bind_global(callback);
+    return this;
+  }
+
+  unbind_global(callback? : Function) : Pusher {
+    this.global_emitter.unbind_global(callback);
+    return this;
+  }
+
+  unbind_all(callback? : Function) : Pusher {
+    this.global_emitter.unbind_all();
     return this;
   }
 

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -193,8 +193,8 @@ export default class Pusher {
     return this;
   }
 
-  bind_all(callback : Function) : Pusher {
-    this.global_emitter.bind_all(callback);
+  bind_global(callback : Function) : Pusher {
+    this.global_emitter.bind_global(callback);
     return this;
   }
 

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -189,7 +189,7 @@ export default class Pusher {
   }
 
   unbind(event_name? : string, callback? : Function, context? : any) : Pusher {
-    this.global_emitter.unbind(event_name, callback);
+    this.global_emitter.unbind(event_name, callback, context);
     return this;
   }
 


### PR DESCRIPTION
A customer pointed out that `unbind_all` didn't do what they expected. In particular it didn't reverse `bind_all`. Upon further inspection `unbind_all` was implemented identically to `unbind` and in fact all occurrences of `unbind_all()` can safely be replaced by `unbind()`. This also means that there is no way of removing global bindings (of the `bind_all` variety) short of directly mutating `channel.global_callbacks`.

After discussion in Slack we came to the conclusion that an `unbind_all` method should do just that, remove *all* bindings, and that `bind_all` should be replaced by `bind_global` and it's inverse `unbind_global` to avoid ambiguity.

This is a breaking change, but any use of `unbind_all()` will continue to work as expected (unless anyone was exploiting the fact that `unbind_all()` previously left global bindings alone) and `bind_all` seems to have been discouraged in the docs, so the change to `bind_global` shouldn't affect a huge number of people.