### PR TITLE
Allow specifying a custom authorizer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -156,6 +156,23 @@ var pusher = new Pusher(API_KEY, {
 });
 ```
 
+#### `authorizer` (Function)
+
+If you need custom authorization behavior you can provide your own `authorizer` function as follows:
+
+```js
+var pusher = new Pusher(API_KEY, {
+  authorizer: function(channel, options) {
+    return {
+      authorize: function(socketId, callback) {
+        // Do some ajax to get the auth information
+        callback(false, authInformation);
+      }
+    };
+  }
+})
+```
+
 #### `cluster` (String)
 
 Allows connecting to a different datacenter by setting up correct hostnames and ports for the connection.

--- a/spec/javascripts/unit/core/channels/private_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/private_channel_spec.js
@@ -7,6 +7,7 @@ var Mocks = require("mocks");
 describe("PrivateChannel", function() {
   var pusher;
   var channel;
+  var factorySpy;
 
   beforeEach(function() {
     pusher = Mocks.getPusher({ foo: "bar" });
@@ -32,7 +33,7 @@ describe("PrivateChannel", function() {
 
     beforeEach(function() {
       authorizer = Mocks.getAuthorizer();
-      spyOn(Factory, "createAuthorizer").andReturn(authorizer);
+      factorySpy = spyOn(Factory, "createAuthorizer").andReturn(authorizer);
     });
 
     it("should create and call an authorizer", function() {
@@ -52,6 +53,25 @@ describe("PrivateChannel", function() {
       authorizer._callback(false, { foo: "bar" });
 
       expect(callback).toHaveBeenCalledWith(false, { foo: "bar" });
+    });
+
+    describe('with custom authorizer', function() {
+      beforeEach(function() {
+        pusher = Mocks.getPusher({ 
+          authorizer: function(channel, options) {
+            return authorizer;
+          }
+        });
+        channel = new PrivateChannel("private-test-custom-auth", pusher);
+        factorySpy.andCallThrough();
+      });
+
+      it("should call the authorizer", function() {
+        var callback = jasmine.createSpy("callback");
+        channel.authorize("1.23", callback);
+        authorizer._callback(false, { foo: "bar" });
+        expect(callback).toHaveBeenCalledWith(false, { foo: "bar" });
+      });
     });
   });
 

--- a/src/core/auth/options.ts
+++ b/src/core/auth/options.ts
@@ -6,11 +6,15 @@ export interface AuthOptions {
 }
 
 export interface Authorizer {
-	authorize: (socketId : string, callback : Function)
+	authorize(socketId : string, callback : Function)
+}
+
+export interface AuthorizerGenerator {
+  (channel: Channel, options : AuthorizerOptions): Authorizer
 }
 
 export interface AuthorizerOptions {
   authTransport: "ajax" | "jsonp";
   auth: AuthOptions;
-  authorizer(channel : Channel, options : AuthorizerOptions): Authorizer;
+  authorizer: AuthorizerGenerator;
 }

--- a/src/core/auth/options.ts
+++ b/src/core/auth/options.ts
@@ -1,9 +1,16 @@
+import Channel from "../channels/channel";
+
 export interface AuthOptions {
   params: any;
   headers : any;
 }
 
+export interface Authorizer {
+	authorize: (socketId : string, callback : Function)
+}
+
 export interface AuthorizerOptions {
   authTransport: "ajax" | "jsonp";
   auth: AuthOptions;
+  authorizer(channel : Channel, options : AuthorizerOptions): Authorizer;
 }

--- a/src/core/auth/pusher_authorizer.ts
+++ b/src/core/auth/pusher_authorizer.ts
@@ -3,9 +3,9 @@ import Channel from '../channels/channel';
 import Factory from '../utils/factory';
 import Runtime from 'runtime';
 import {AuthTransports} from './auth_transports';
-import {AuthOptions, AuthorizerOptions} from './options';
+import {AuthOptions, AuthorizerOptions, Authorizer} from './options';
 
-export default class Authorizer {
+export default class PusherAuthorizer implements Authorizer {
   static authorizers : AuthTransports;
 
   channel: Channel;
@@ -39,7 +39,7 @@ export default class Authorizer {
   }
 
   authorize(socketId : string, callback : Function) : any {
-    Authorizer.authorizers = Authorizer.authorizers || Runtime.getAuthorizers();
-    return Authorizer.authorizers[this.type].call(this, Runtime, socketId, callback);
+    PusherAuthorizer.authorizers = PusherAuthorizer.authorizers || Runtime.getAuthorizers();
+    return PusherAuthorizer.authorizers[this.type].call(this, Runtime, socketId, callback);
   }
 }

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,5 +1,5 @@
 import ConnectionManager from './connection/connection_manager';
-import {AuthOptions} from './auth/options';
+import {AuthOptions, AuthorizerGenerator} from './auth/options';
 
 interface PusherOptions {
   cluster: string;
@@ -12,6 +12,7 @@ interface PusherOptions {
   timelineParams: any;
   authTransport: "ajax" | "jsonp";
   auth: AuthOptions;
+  authorizer: AuthorizerGenerator;
 }
 
 export default PusherOptions;

--- a/src/core/utils/factory.ts
+++ b/src/core/utils/factory.ts
@@ -6,8 +6,8 @@ import Handshake from "../connection/handshake";
 import TransportConnection from "../transports/transport_connection";
 import SocketHooks from "../http/socket_hooks";
 import HTTPSocket from "../http/http_socket";
-import Authorizer from "../auth/pusher_authorizer";
-import {AuthorizerOptions} from '../auth/options';
+import {AuthorizerOptions, Authorizer} from '../auth/options';
+import PusherAuthorizer from '../auth/pusher_authorizer';
 import Timeline from "../timeline/timeline";
 import {default as TimelineSender, TimelineSenderOptions} from "../timeline/timeline_sender";
 import PresenceChannel from "../channels/presence_channel";
@@ -46,7 +46,11 @@ var Factory = {
   },
 
   createAuthorizer(channel : Channel, options : AuthorizerOptions) : Authorizer {
-    return new Authorizer(channel, options);
+    if (options.authorizer) {
+      return options.authorizer(channel, options);
+    }
+
+    return new PusherAuthorizer(channel, options);
   },
 
   createHandshake(transport : TransportConnection, callback : (HandshakePayload)=>void) : Handshake {


### PR DESCRIPTION
## What does this PR do?

This PR adds an option to use when configuring the Pusher client to override the behavior of the authorization.  My original use case was needing to pass a header along with my request that was only known at the time of the request and this solves that problem but also seems to solve a few other open issues.  Most importantly https://github.com/pusher/pusher-js/issues/165.

Open to suggestions for improvements.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.

/cc @hph
