### PR TITLE
worker: fetch_auth: Send credentials

### DIFF
--- a/src/runtimes/worker/auth/fetch_auth.ts
+++ b/src/runtimes/worker/auth/fetch_auth.ts
@@ -14,6 +14,7 @@ var fetchAuth : AuthTransport = function(context, socketId, callback){
   var request = new Request(this.options.authEndpoint, {
     headers,
     body,
+    credentials: "same-origin",
     method: "POST",
   });
 


### PR DESCRIPTION
## What does this PR do?

By default the Fetch API doesn't send any cookies, even for same-origin
requests [1].  This presents a problem when using the fetch API against a
web framework that relies on cookies for authentication (like Django).

Note that the worker runtime is typically not used from the browser, except
when needed to work around issues with conflicts between multiple versions
of Pusher existing on the same page.  One example of when this happens is
if a third-party widget is bundling Pusher, and the main app is also trying
to use it.  For example: [2].

Without this patch, it's not possible to set up authenticated connections
against a Django app with CSRF protection enabled while using the worker
runtime.  With the patch, all's well.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
[2] https://github.com/pusher/pusher-js/issues/158#issuecomment-274242084

## Checklist

- [X] All new functionality has tests. (no new functionality (depending on how you defined "functionality" ;) )
- [X] All tests are passing. (Ran for about 5 minutes and seemed to be looping endlessly?)
- [X] New or changed API methods have been documented. (N/A)

/cc @hph @hot-leaf-juice 
