### PR TITLE
Change .done() to .then() in react-native

### DIFF
--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -14,7 +14,7 @@ export class NetInfo extends EventsDispatcher implements Reachability {
     super();
     this.online = true;
 
-    NativeNetInfo.fetch().done((connectionState)=>{
+    NativeNetInfo.fetch().then((connectionState)=>{
       this.online = hasOnlineConnectionState(connectionState);
     });
 


### PR DESCRIPTION
## What does this PR do?

Calling .done() crashed app on react-native@0.42.3 with .done undefined.

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.

/cc @hph
