### PR TITLE
reset subscriptionPending if disconnect happens while subscribing

### DIFF
--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -64,6 +64,14 @@ describe("Channel", function() {
       channel.disconnect();
       expect(channel.subscribed).toEqual(false);
     });
+
+    it("should set subscriptionPending to false", function() {
+      channel.subscriptionPending = true;
+      
+      channel.disconnect();
+
+      expect(channel.subscriptionPending).toEqual(false);
+    });
   });
 
   describe("#handleEvent", function() {

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -52,6 +52,7 @@ export default class Channel extends EventsDispatcher {
   /** Signals disconnection to the channel. For internal use only. */
   disconnect() {
     this.subscribed = false;
+    this.subscriptionPending = false;
   }
 
   /** Handles an event. For internal use only.


### PR DESCRIPTION
## What does this PR do?

If Pusher disconnects (manually, or when network blips out and changes) while a channel subscription is happening (but is not yet successful), the channel is stuck in a pending subscription state. This means that when Pusher re-establishes connection and tries to re-subscribe channels, it skips over channels that are pending subscription. 

This results in the issue seen in #223 , and can be reproduced by going to http://test.pusher.com/, click disconnect button, then quickly click the connect and then disconnect again before the pusher channel subscription succeeds.


This fix resets `Channel.subscriptionPending` to `false` when a disconnect happens.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.

/cc @hph
