### PR TITLE
Update React Native NetInfo usage -- 'change' and 'fetch()' deprecated

### DIFF
--- a/dist/react-native/pusher.js
+++ b/dist/react-native/pusher.js
@@ -1702,7 +1702,7 @@ module.exports =
 	var react_native_1 = __webpack_require__(27);
 	var dispatcher_1 = __webpack_require__(14);
 	function hasOnlineConnectionState(connectionState) {
-	    return connectionState.toLowerCase() !== "none";
+	    return connectionState.type.toLowerCase() !== "none";
 	}
 	var NetInfo = (function (_super) {
 	    __extends(NetInfo, _super);
@@ -1710,10 +1710,10 @@ module.exports =
 	        var _this = this;
 	        _super.call(this);
 	        this.online = true;
-	        react_native_1.NetInfo.fetch().then(function (connectionState) {
+	        react_native_1.NetInfo.getConnectionInfo().then(function (connectionState) {
 	            _this.online = hasOnlineConnectionState(connectionState);
 	        });
-	        react_native_1.NetInfo.addEventListener('change', function (connectionState) {
+	        react_native_1.NetInfo.addEventListener('connectionChange', function (connectionState) {
 	            var isNowOnline = hasOnlineConnectionState(connectionState);
 	            if (_this.online === isNowOnline)
 	                return;

--- a/dist/react-native/pusher.js
+++ b/dist/react-native/pusher.js
@@ -1711,7 +1711,7 @@ module.exports =
 	        _super.call(this);
 	        this.online = true;
 	        react_native_1.NetInfo.getConnectionInfo().then(function (connectionState) {
-	            _this.online = hasOnlineConnectionState(connectionState);
+	            this.online = hasOnlineConnectionState(connectionState);
 	        });
 	        react_native_1.NetInfo.addEventListener('connectionChange', function (connectionState) {
 	            var isNowOnline = hasOnlineConnectionState(connectionState);

--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -4,7 +4,7 @@ import Util from 'core/util';
 import Reachability from 'core/reachability';
 
 function hasOnlineConnectionState(connectionState) : boolean{
-  return connectionState.toLowerCase() !== "none";
+  return connectionState.type.toLowerCase() !== "none";
 }
 
 export class NetInfo extends EventsDispatcher implements Reachability {
@@ -14,11 +14,11 @@ export class NetInfo extends EventsDispatcher implements Reachability {
     super();
     this.online = true;
 
-    NativeNetInfo.fetch().then((connectionState)=>{
+    NativeNetInfo.getConnectionInfo().then(function (connectionState) {
       this.online = hasOnlineConnectionState(connectionState);
     });
 
-    NativeNetInfo.addEventListener('change', (connectionState)=>{
+    NativeNetInfo.addEventListener('connectionChange', (connectionState)=>{
       var isNowOnline = hasOnlineConnectionState(connectionState);
 
       // React Native counts the switch from Wi-Fi to Cellular


### PR DESCRIPTION

## What does this PR do?

Update React Native NetInfo usage ('change' event and 'fetch' module deprecated)

## Checklist

- [X] All new functionality has tests.
- [X] All tests are passing.
- [X] New or changed API methods have been documented.

/cc @hph
