### PR TITLE
Re-auth a single time if decryption fails

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -7,3 +7,4 @@ export class UnsupportedFeature extends Error {}
 export class UnsupportedTransport extends Error {}
 export class UnsupportedStrategy extends Error {}
 export class EncryptionError extends Error {}
+export class EncryptionKeyError extends Error {}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -6,5 +6,3 @@ export class TransportClosed extends Error {}
 export class UnsupportedFeature extends Error {}
 export class UnsupportedTransport extends Error {}
 export class UnsupportedStrategy extends Error {}
-export class EncryptionError extends Error {}
-export class EncryptionKeyError extends Error {}


### PR DESCRIPTION
## What does this PR do?

Attempts a single re-auth if decryption fails in case the key has been rotated. IMO the odds of a re-auth succeeding on the subsequent retries is low enough that it's not worth the added conceptual complexity at this point.

The other significant change is that rather than throwing errors, warnings are logged. This is what we are doing in other error cases when handling events:

https://github.com/pusher/pusher-js/blob/807b778463851f3a9b02114abf06f00f65e94d8f/src/core/pusher.ts#L151

So I thought it was better to keep it consistent. I'm not sure what even happens when throwing exceptions in "bind" callbacks. I actually think emitting error events which users can bind to would be the best approach, but not something I want to tackle now.

I also inlined the `handleEncryptedEvent` code. I think it's simpler to follow; there are no exceptions that need to be thrown by `decryptPayload` and handled in the layer above.

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [x] New or changed API methods have been documented.

/cc @hph
