### PR TITLE
Respect error codes when connected

### DIFF
--- a/spec/javascripts/unit/core/connection/connection_manager_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_manager_spec.js
@@ -453,6 +453,13 @@ describe("ConnectionManager", function() {
         expect(manager.state).toEqual("connecting");
       });
     });
+
+    describe("on refused", function() {
+      it("should disconnect upon receipt of a refused event" function() {
+        connection.emit("refused");
+        expect(manager.state).toEqual("disconnected");
+      });
+    });
   });
 
   describe("after establishing a connection which handles activity checks by iself", function() {

--- a/spec/javascripts/unit/core/connection/connection_manager_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_manager_spec.js
@@ -454,10 +454,50 @@ describe("ConnectionManager", function() {
       });
     });
 
-    describe("on refused", function() {
-      it("should disconnect upon receipt of a refused event" function() {
-        connection.emit("refused");
+    describe("on error callback", function() {
+      var errorHandler;
+      beforeEach(function() {
+        errorHandler = jasmine.createSpy();
+        manager.bind("error", errorHandler)
+      });
+      it("should emit error and disconnect upon receipt of a refused event", function() {
+        var error = {code: 4000};
+        connection.emit("refused", {error: error});
         expect(manager.state).toEqual("disconnected");
+        expect(errorHandler).toHaveBeenCalledWith({
+          type: 'WebSocketError',
+          error:  error
+        });
+      });
+      it("should emit error and reconnect upon receipt of a tls_only event", function() {
+        var error = {code: 4000};
+        connection.emit("tls_only", {error: error});
+        jasmine.Clock.tick(1);
+        expect(manager.state).toEqual("connecting");
+        expect(errorHandler).toHaveBeenCalledWith({
+          type: 'WebSocketError',
+          error:  error
+        });
+      });
+      it("should emit error and reconnect with backoff upon receipt of a backoff event", function() {
+        var error = {code: 4100};
+        connection.emit("backoff", {error: error});
+        jasmine.Clock.tick(1000);
+        expect(manager.state).toEqual("connecting");
+        expect(errorHandler).toHaveBeenCalledWith({
+          type: 'WebSocketError',
+          error:  error
+        });
+      });
+      it("should emit error and reconnect upon receipt of a retry event", function() {
+        var error = {code: 4200};
+        connection.emit("retry", {error: error});
+        jasmine.Clock.tick(1);
+        expect(manager.state).toEqual("connecting");
+        expect(errorHandler).toHaveBeenCalledWith({
+          type: 'WebSocketError',
+          error:  error
+        });
       });
     });
   });

--- a/src/core/connection/callbacks.ts
+++ b/src/core/connection/callbacks.ts
@@ -17,5 +17,4 @@ export interface ConnectionCallbacks {
   activity: () => void;
   error: (error : any) => void;
   closed: () => void;
-  refused: () => void;
 }

--- a/src/core/connection/callbacks.ts
+++ b/src/core/connection/callbacks.ts
@@ -1,10 +1,11 @@
 import HandshakePayload from './handshake/handshake_payload';
+import Action from './protocol/action';
 
 export interface ErrorCallbacks {
-  tls_only: (result: HandshakePayload) => void;
-  refused: (result: HandshakePayload) => void;
-  backoff: (result: HandshakePayload) => void;
-  retry: (result: HandshakePayload) => void;
+  tls_only: (result: Action | HandshakePayload) => void;
+  refused: (result: Action | HandshakePayload) => void;
+  backoff: (result: Action | HandshakePayload) => void;
+  retry: (result: Action | HandshakePayload) => void;
 }
 
 export interface HandshakeCallbacks {

--- a/src/core/connection/callbacks.ts
+++ b/src/core/connection/callbacks.ts
@@ -17,4 +17,5 @@ export interface ConnectionCallbacks {
   activity: () => void;
   error: (error : any) => void;
   closed: () => void;
+  refused: () => void;
 }

--- a/src/core/connection/connection.ts
+++ b/src/core/connection/connection.ts
@@ -151,7 +151,7 @@ export default class Connection extends EventsDispatcher implements Socket {
        this.emit('error', error);
      }
      if (action) {
-       this.emit(action, error ? error : undefined);
+       this.emit(action, {action: action, error: error});
      }
    }
 }

--- a/src/core/connection/connection.ts
+++ b/src/core/connection/connection.ts
@@ -151,7 +151,7 @@ export default class Connection extends EventsDispatcher implements Socket {
        this.emit('error', error);
      }
      if (action) {
-       this.emit(action);
+       this.emit(action, error ? error : undefined);
      }
    }
 }

--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -10,6 +10,7 @@ import Timeline from '../timeline/timeline';
 import ConnectionManagerOptions from './connection_manager_options';
 import Runtime from 'runtime';
 import {ErrorCallbacks, HandshakeCallbacks, ConnectionCallbacks} from './callbacks';
+import Action from './protocol/action';
 
 /** Manages connection to Pusher.
  *
@@ -289,7 +290,7 @@ export default class ConnectionManager extends EventsDispatcher {
 
   private buildErrorCallbacks() : ErrorCallbacks {
     let withErrorEmitted = (callback)=> {
-      return (result)=> {
+      return (result: Action | HandshakePayload)=> {
         if (result.error) {
           this.emit("error", { type: "WebSocketError", error: result.error });
         }

--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -267,6 +267,9 @@ export default class ConnectionManager extends EventsDispatcher {
         if (this.shouldRetry()) {
           this.retryIn(1000);
         }
+      },
+      refused: ()=> {
+        this.disconnect();
       }
     };
   };

--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -64,8 +64,8 @@ export default class ConnectionManager extends EventsDispatcher {
     this.usingTLS = !!options.useTLS;
     this.timeline = this.options.timeline;
 
-    this.connectionCallbacks = this.buildConnectionCallbacks();
     this.errorCallbacks = this.buildErrorCallbacks();
+    this.connectionCallbacks = this.buildConnectionCallbacks(this.errorCallbacks);
     this.handshakeCallbacks = this.buildHandshakeCallbacks(this.errorCallbacks);
 
     var Network = Runtime.getNetwork();
@@ -245,8 +245,8 @@ export default class ConnectionManager extends EventsDispatcher {
     }
   };
 
-  private buildConnectionCallbacks() : ConnectionCallbacks {
-    return {
+  private buildConnectionCallbacks(errorCallbacks: ErrorCallbacks) : ConnectionCallbacks {
+    return Collections.extend<ConnectionCallbacks>({}, errorCallbacks, {
       message: (message)=> {
         // includes pong messages from server
         this.resetActivityCheck();
@@ -267,11 +267,8 @@ export default class ConnectionManager extends EventsDispatcher {
         if (this.shouldRetry()) {
           this.retryIn(1000);
         }
-      },
-      refused: ()=> {
-        this.disconnect();
       }
-    };
+    });
   };
 
   private buildHandshakeCallbacks(errorCallbacks : ErrorCallbacks) : HandshakeCallbacks {

--- a/src/core/connection/handshake/handshake_payload.ts
+++ b/src/core/connection/handshake/handshake_payload.ts
@@ -2,12 +2,9 @@ import TransportConnection from "../../transports/transport_connection";
 import Action from "../protocol/action";
 import Connection from "../connection";
 
-interface HandshakePayload {
+interface HandshakePayload extends Action {
   transport: TransportConnection;
-  action: Action;
   connection?: Connection;
-  activityTimeout?: number;
-  error: any;
 }
 
 export default HandshakePayload;


### PR DESCRIPTION
## What does this PR do?

At the moment, error codes/close actions are only respected when they're received during a handshake. Pusher server can close active connections with error codes that should be respected too (e.g. non-authorized connections are closed with a `4009` error)

This PR updates the connection manager to bind the error callbacks to the connection, aswell as the connection callbacks.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [ ] New or changed API methods have been documented.
