### PR TITLE
update README cdn version to 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following topics are covered:
 * [Connection](https://github.com/pusher/pusher-js#connection)
   * [Socket IDs](https://github.com/pusher/pusher-js#socket-ids)
 * [Subscribing to Channels (Public and Private)](https://github.com/pusher/pusher-js#subscribing-to-channels)
+* [Accessing Channels](https://github.com/pusher/pusher-js#accessing-channels)
 * [Binding to Events](https://github.com/pusher/pusher-js#binding-to-events)
 * [Default events](https://github.com/pusher/pusher-js#default-events)
 * [Developing](https://github.com/pusher/pusher-js#developing)
@@ -60,7 +61,7 @@ const Pusher = require('pusher-js');
 #### CDN
 
 ```html
-<script src="https://js.pusher.com/4.2/pusher.min.js"></script>
+<script src="https://js.pusher.com/4.3/pusher.min.js"></script>
 ```
 
 You can also use [cdnjs.com](https://cdnjs.com/libraries/pusher) if you prefer
@@ -99,7 +100,7 @@ Notes:
 You can import the worker script (`pusher.worker.js`, not `pusher.js`) from the CDN:
 
 ```javascript
-importScripts('https://js.pusher.com/4.2/pusher.worker.min.js');
+importScripts('https://js.pusher.com/4.3/pusher.worker.min.js');
 ```
 
 ### Node.js
@@ -366,6 +367,8 @@ Please note that encrypted channels are only officially supported for our 'web' 
 const channel = socket.subscribe('private-encrypted-my-channel');
 ```
 
+## Accessing Channels
+
 It is possible to access channels by name, through the `channel` function:
 
 ```js
@@ -496,17 +499,17 @@ First, clone this repository and run `npm install && git submodule init && git s
 
 In the `dist/web` folder, you should see the files you need: `pusher.js`, `pusher.min.js`, `json2.js`, `json.min.js`, `sockjs.js` and `sockjs.min.js`. `pusher.js` should be built referencing your URLs as the dependency hosts.
 
-First, make sure you expose all files from the `dist` directory. They need to be in a directory with named after the version number. For example, if you're hosting version 4.2.0 under `http://example.com/pusher-js` (and https for SSL), files should be accessible under following URL's:
+First, make sure you expose all files from the `dist` directory. They need to be in a directory with named after the version number. For example, if you're hosting version 4.3.0 under `http://example.com/pusher-js` (and https for SSL), files should be accessible under following URL's:
 
-    http://example.com/pusher-js/4.2.0/pusher.js
-    http://example.com/pusher-js/4.2.0/json2.js
-    http://example.com/pusher-js/4.2.0/sockjs.js
+    http://example.com/pusher-js/4.3.0/pusher.js
+    http://example.com/pusher-js/4.3.0/json2.js
+    http://example.com/pusher-js/4.3.0/sockjs.js
 
 Minified files should have `.min` in their names, as in the `dist/web` directory:
 
-    http://example.com/pusher-js/4.2.0/pusher.min.js
-    http://example.com/pusher-js/4.2.0/json2.min.js
-    http://example.com/pusher-js/4.2.0/sockjs.min.js
+    http://example.com/pusher-js/4.3.0/pusher.min.js
+    http://example.com/pusher-js/4.3.0/json2.min.js
+    http://example.com/pusher-js/4.3.0/sockjs.min.js
 
 ## SockJS compatibility
 


### PR DESCRIPTION
## What does this PR do?

It updates the README regarding the cdn urls changing the version from `4.2` to `4.3`, the one that supports end-to-end Encryption right now.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
