### PR TITLE
Error if events triggered pre-subscription

### DIFF
--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -35,10 +35,19 @@ describe("Channel", function() {
   });
 
   describe("#trigger", function() {
+    beforeEach(function() {
+      channel.subscribed = true;
+    });
     it("should raise an exception if the event name does not start with client-", function() {
       expect(function() {
         channel.trigger("whatever", {});
       }).toThrow(jasmine.any(Errors.BadEventName));
+    });
+    it("should raise an exception if the channel isn't subscribed", function() {
+      channel.subscribed = false;
+      expect(function() {
+        channel.trigger("client-example", {});
+      }).toThrow(jasmine.any(Errors.TriggerError));
     });
 
     it("should call send_event on connection", function() {

--- a/spec/javascripts/unit/core/channels/presence_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/presence_channel_spec.js
@@ -89,6 +89,9 @@ describe("PresenceChannel", function() {
   });
 
   describe("#trigger", function() {
+    beforeEach(function() {
+      channel.subscribed = true;
+    });
     it("should raise an exception if the event name does not start with client-", function() {
       expect(function() {
         channel.trigger("whatever", {});

--- a/spec/javascripts/unit/core/channels/private_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/private_channel_spec.js
@@ -76,6 +76,9 @@ describe("PrivateChannel", function() {
   });
 
   describe("#trigger", function() {
+    beforeEach(function() {
+      channel.subscribed = true;
+    })
     it("should raise an exception if the event name does not start with client-", function() {
       expect(function() {
         channel.trigger("whatever", {});

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -49,8 +49,8 @@ export default class Channel extends EventsDispatcher {
     }
     if (!this.subscribed) {
       var suffix = UrlStore.buildLogSuffix("triggeringClientEvents");
-      throw new Errors.TriggerError(
-        `Event triggered before channel subscription complete. ${suffix}`
+      Logger.warn(
+        `Client event triggered before channel 'subscription_succeeded' event . ${suffix}`
       );
     }
     return this.pusher.send_event(event, data, this.name);

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -2,6 +2,7 @@ import {default as EventsDispatcher} from '../events/dispatcher';
 import * as Errors from '../errors';
 import Logger from '../logger';
 import Pusher from '../pusher';
+import UrlStore from '../utils/url_store';
 
 /** Provides base public channel interface with an event emitter.
  *
@@ -44,6 +45,12 @@ export default class Channel extends EventsDispatcher {
     if (event.indexOf("client-") !== 0) {
       throw new Errors.BadEventName(
         "Event '" + event + "' does not start with 'client-'"
+      );
+    }
+    if (!this.subscribed) {
+      var suffix = UrlStore.buildLogSuffix("triggeringClientEvents");
+      throw new Errors.TriggerError(
+        `Event triggered before channel subscription complete. ${suffix}`
       );
     }
     return this.pusher.send_event(event, data, this.name);

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -6,3 +6,4 @@ export class TransportClosed extends Error {}
 export class UnsupportedFeature extends Error {}
 export class UnsupportedTransport extends Error {}
 export class UnsupportedStrategy extends Error {}
+export class TriggerError extends Error {}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -6,4 +6,3 @@ export class TransportClosed extends Error {}
 export class UnsupportedFeature extends Error {}
 export class UnsupportedTransport extends Error {}
 export class UnsupportedStrategy extends Error {}
-export class TriggerError extends Error {}

--- a/src/core/utils/url_store.ts
+++ b/src/core/utils/url_store.ts
@@ -11,6 +11,9 @@ const urlStore = {
     javascriptQuickStart: {
       path: "/docs/javascript_quick_start"
     },
+    triggeringClientEvents: {
+      path: "/docs/client_api_guide/client_events#trigger-events"
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Throws an error if client events are triggered before subscription completes

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [ ] New or changed API methods have been documented.
