### PR TITLE
Re-enable CI with Travis+BrowserStack

### DIFF
--- a/.travis.build
+++ b/.travis.build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+  export CI='full' ;
+else
+  export CI='basic' ;
+fi
+
+make web_unit && make web_integration

--- a/.travis.build
+++ b/.travis.build
@@ -8,7 +8,14 @@ else
   export CI='basic' ;
 fi
 
+echo "Running web unit tests..."
 make web_unit
+echo "Running web integration tests..."
 make web_integration
+
+
+echo "Running node unit tests..."
 make node_unit
+
+echo "Running node integration tests..."
 make node_integration

--- a/.travis.build
+++ b/.travis.build
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
   export CI='full' ;
 else
   export CI='basic' ;
@@ -10,9 +10,9 @@ fi
 
 echo "Running web unit tests..."
 make web_unit
+
 echo "Running web integration tests..."
 make web_integration
-
 
 echo "Running node unit tests..."
 make node_unit

--- a/.travis.build
+++ b/.travis.build
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+set -e
+
 if [ "$TRAVIS_BRANCH" == "master" ]; then
   export CI='full' ;
 else
   export CI='basic' ;
 fi
 
-make web_unit && make web_integration
+make web_unit
+make web_integration
+make node_unit
+make node_integration
+make worker_unit
+make worker_integration

--- a/.travis.build
+++ b/.travis.build
@@ -12,5 +12,3 @@ make web_unit
 make web_integration
 make node_unit
 make node_integration
-make worker_unit
-make worker_integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js: "5.1"
+before_script:
+  - npm install
+script:
+  - ./.travis.build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "5.1"
+node_js: "10"
 before_script:
   - npm install
 script:

--- a/spec/config/karma/config.ci.js
+++ b/spec/config/karma/config.ci.js
@@ -3,49 +3,11 @@ var config = {
     startTunnel: true
   },
   customLaunchers: {
-    bs_ie8: {
+    bs_chrome_73: {
       base: 'BrowserStack',
-      browser: 'ie',
-      browser_version: '8.0',
-      os: "Windows",
-      os_version: '7'
-    },
-    bs_ie7: {
-      base: 'BrowserStack',
-      os_version: "XP",
-      browser: "ie",
-      browser_version: "7.0",
-      os: "Windows"
-    },
-    bs_opera_12_15: {
-      base: 'BrowserStack',
-      os_version: "8",
-      browser: "opera",
-      browser_version: "12.15",
-      os: "Windows"
-    },
-    bs_firefox_3_6: {
-      base: 'BrowserStack',
-      os_version: "7",
-      browser: "firefox",
-      browser_version: "3.6",
-      device: null,
-      os: "Windows"
-    },
-    bs_chrome_49: {
-      base: 'BrowserStack',
-      os_version: "El Capitan",
-      browser: "chrome",
-      browser_version: "49.0",
-      device: null,
-      os: "OS X"
-    },
-    bs_safari_5: {
-      base: 'BrowserStack',
-      os_version: "Snow Leopard",
-      browser: "safari",
-      browser_version: "5.1",
-      device: null,
+      os_version: "Mojave",
+      browser: "Chrome",
+      browser_version: "73.0",
       os: "OS X"
     }
   }
@@ -54,7 +16,7 @@ var config = {
 if (process.env.CI === 'full') {
   config.browsers = Object.keys(config.customLaunchers);
 } else {
-  config.browsers = ['bs_ie7', 'bs_ie8', 'bs_opera_12_15'];
+  config.browsers = ['bs_chrome_73'];
 }
 
 module.exports = config;

--- a/spec/config/karma/config.ci.js
+++ b/spec/config/karma/config.ci.js
@@ -1,6 +1,7 @@
 var config = {
   browserStack: {
-    startTunnel: true
+    startTunnel: true,
+    timeout: 1800
   },
   customLaunchers: {
     bs_chrome_73: {

--- a/spec/config/karma/config.ci.js
+++ b/spec/config/karma/config.ci.js
@@ -4,11 +4,25 @@ var config = {
     timeout: 1800
   },
   customLaunchers: {
-    bs_chrome_73: {
+    bs_chrome_74: {
       base: 'BrowserStack',
       os_version: "Mojave",
       browser: "Chrome",
-      browser_version: "73.0",
+      browser_version: "74.0",
+      os: "OS X"
+    },
+    bs_firefox_66: {
+      base: 'BrowserStack',
+      os_version: "Mojave",
+      browser: "Firefox",
+      browser_version: "66.0",
+      os: "OS X"
+    },
+    bs_safari_12: {
+      base: 'BrowserStack',
+      os_version: "Mojave",
+      browser: "Safari",
+      browser_version: "12",
       os: "OS X"
     }
   }
@@ -17,7 +31,7 @@ var config = {
 if (process.env.CI === 'full') {
   config.browsers = Object.keys(config.customLaunchers);
 } else {
-  config.browsers = ['bs_chrome_73'];
+  config.browsers = ['bs_chrome_74'];
 }
 
 module.exports = config;

--- a/spec/config/karma/config.common.js
+++ b/spec/config/karma/config.common.js
@@ -33,7 +33,7 @@ module.exports = {
   colors: true,
   autoWatch: true,
 
-  browsers: ['Chrome'],
+  browsers: ['Chrome', 'Firefox', 'Opera', 'Safari'],
   captureTimeout: 3e5,
   browserNoActivityTimeout: 3e5,
   browserDisconnectTimeout: 3e5,

--- a/spec/config/karma/config.common.js
+++ b/spec/config/karma/config.common.js
@@ -2,7 +2,7 @@ module.exports = {
   basePath: '../../../',
   frameworks: ["jasmine"],
 
-  reporters: ['coverage', 'verbose'],
+  reporters: ['coverage', 'dots'],
 
   coverageReporter: {
     type : 'html',
@@ -33,11 +33,14 @@ module.exports = {
   colors: true,
   autoWatch: true,
 
-  browsers: ['Chrome', 'Firefox', 'Opera', 'Safari'],
+  browsers: ['Chrome'],
   captureTimeout: 3e5,
   browserNoActivityTimeout: 3e5,
   browserDisconnectTimeout: 3e5,
   browserDisconnectTolerance: 3,
 
-  singleRun: true
+  singleRun: true,
+  client: {
+    captureConsole: false,
+  }
 }

--- a/spec/config/karma/integration.js
+++ b/spec/config/karma/integration.js
@@ -13,7 +13,7 @@ if (process.env.WORKER === 'true') {
     pusher_integration: 'core',
     integration: 'node/integration'
   }
-  if (process.env.CI) config.browsers = ['bs_chrome_49'];
+  if (process.env.CI) config.browsers = ['bs_chrome_73'];
 }
 
 module.exports = function(suite) {

--- a/spec/config/karma/integration.js
+++ b/spec/config/karma/integration.js
@@ -13,7 +13,7 @@ if (process.env.WORKER === 'true') {
     pusher_integration: 'core',
     integration: 'node/integration'
   }
-  if (process.env.CI) config.browsers = ['bs_chrome_73'];
+  if (process.env.CI) config.browsers = ['bs_chrome_74'];
 }
 
 module.exports = function(suite) {

--- a/spec/config/karma/unit.js
+++ b/spec/config/karma/unit.js
@@ -11,7 +11,7 @@ if (process.env.WORKER === 'true') {
   config = require('./config.worker')(config, 'unit');
 
   // only run worker test on Chrome for CI
-  if (process.env.CI) config.browsers = ['bs_chrome_73'];
+  if (process.env.CI) config.browsers = ['bs_chrome_74'];
 }
 
 module.exports = function(suite) {

--- a/spec/config/karma/unit.js
+++ b/spec/config/karma/unit.js
@@ -15,6 +15,6 @@ if (process.env.WORKER === 'true') {
 }
 
 module.exports = function(suite) {
-  config.logLevel = suite.LOG_INFO,
+  config.logLevel = suite.LOG_DISABLE;
   suite.set(config);
 };

--- a/spec/config/karma/unit.js
+++ b/spec/config/karma/unit.js
@@ -11,7 +11,7 @@ if (process.env.WORKER === 'true') {
   config = require('./config.worker')(config, 'unit');
 
   // only run worker test on Chrome for CI
-  if (process.env.CI) config.browsers = ['bs_chrome_49'];
+  if (process.env.CI) config.browsers = ['bs_chrome_73'];
 }
 
 module.exports = function(suite) {

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -228,7 +228,7 @@ describe("Channel", function() {
 
       expect(pusher.send_event).toHaveBeenCalledWith(
         "pusher:subscribe",
-        { auth: "one", channel_data: "two", channel: "test" },
+        { auth: "one", channel_data: "two", channel: "test" }
       );
     });
 


### PR DESCRIPTION
## What does this PR do?

This functionality used to exist, and this PR re-adds it.

Unfortunately the tests for older browsers failed with:

```
22 03 2019 15:03:15.138:WARN [launcher.browserstack]: ie 8.0 (Windows 7) has not captured in 300000 ms, killing.
```

See: https://travis-ci.org/pusher/pusher-js/builds/509937975

So I have now configured tests using a new version of Chrome and Mac OS X.

I still think it's more valuable having this tested by CI than not.

We can re-introduce tests for other browsers as future work.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
