### PR TITLE
Replace sockjs module with the root repo rather than a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sockjs-client"]
 	path = src/runtimes/web/dom/sockjs
-	url = git://github.com/pusher/sockjs-client.git
+	url = git://github.com/sockjs/sockjs-client.git


### PR DESCRIPTION
## What does this PR do?

git://github.com/pusher/sockjs-client.git was removed, and the
changed have been moved into git://github.com/sockjs/sockjs-client.git,
see: https://github.com/sockjs/sockjs-client/commit/5b91dbc0e217a9cd959f915fec090370b29878da

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
