### PR TITLE
[Auth] Added a layer to check if headers has custom content-type

### DIFF
--- a/src/runtimes/isomorphic/auth/xhr_auth.ts
+++ b/src/runtimes/isomorphic/auth/xhr_auth.ts
@@ -13,8 +13,12 @@ var ajax : AuthTransport = function(context : AbstractRuntime, socketId, callbac
   xhr = Runtime.createXHR();
   xhr.open("POST", self.options.authEndpoint, true);
 
+  // check for content-type override before adding default
+  if (!this.authOptions.hasOwnProperty('Content-Type')) {
+    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+  }
+
   // add request headers
-  xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
   for(var headerName in this.authOptions.headers) {
     xhr.setRequestHeader(headerName, this.authOptions.headers[headerName]);
   }


### PR DESCRIPTION
## What does this PR do?

In order to override an authentication header, specifically the **Content-Type** we must add it on the headers option upon pusher initialization. But the problem is because the current codebase defaults the content-type to **x-www-form-urlencoded** it only appends the override content-type we appended on construct. So if we wanted the authentication request content-type to be **application/json** it will only append to the default which will result to:

`Content-Type: application/x-www-form-urlencoded, application/json`

In doing so this will cause a confusion on the API side and must abide to a single media type as per  https://greenbytes.de/tech/webdav/rfc2616.html#rfc.section.14.17

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
