### PR TITLE
Replace NetInfo w/ react-native-community version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ and then:
 
 ### React Native
 
+**Warning it's now necessary to install
+[@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo)
+in order to use pusher-js with react-native.** pusher-js depends on NetInfo.
+NetInfo. NetInfo was included within react-native core until v0.60, when it was
+moved to the
+[@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo)
+library. Please follow the [install
+instructions](https://github.com/react-native-community/react-native-netinfo#getting-started)
+for the
+[@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo)
+library before trying to use pusher-js in your react-native project.
+
 Use a package manager like Yarn or NPM to install `pusher-js` and then import
 it as follows:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@react-native-community/netinfo": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.1.1.tgz",
+      "integrity": "sha512-E5AQ2D0qR/uQ7heGSCT8LdDIqGM2Gle7bH8WoQO4zExn4pqz9ZJT1UyysjLnpJthejOU//owbydWqIZE+JNpSA==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/pusher/pusher-js",
   "devDependencies": {
+    "@react-native-community/netinfo": "^4.1.1",
     "faye-websocket": "^0.9.4",
     "fetch-mock": "git+https://git@github.com/jpatel531/fetch-mock.git",
     "isomorphic-fetch": "^2.2.1",

--- a/src/d.ts/react-native/react-native.d.ts
+++ b/src/d.ts/react-native/react-native.d.ts
@@ -1,3 +1,0 @@
-declare module "react-native" {
-  export var NetInfo: any;
-}

--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -1,4 +1,4 @@
-import {NetInfo as NativeNetInfo} from 'react-native';
+import {default as NativeNetInfo} from '@react-native-community/netinfo';
 import EventsDispatcher from 'core/events/dispatcher';
 import Util from 'core/util';
 import Reachability from 'core/reachability';

--- a/webpack/config.react-native.js
+++ b/webpack/config.react-native.js
@@ -14,8 +14,8 @@ module.exports = objectAssign({}, configShared, {
   },
   target: "node",
   externals: {
-    "react-native": "react-native", // our Reachability implementation needs to reference react-native.
-    "@react-native-community/netinfo": "@react-native-community/netinfo", // our Reachability implementation needs to reference react-native.
+    // our Reachability implementation needs to reference @react-native-community/netinfo.
+    "@react-native-community/netinfo": "@react-native-community/netinfo",
   },
   resolve: {
     modules: ['src/runtimes/react-native'],

--- a/webpack/config.react-native.js
+++ b/webpack/config.react-native.js
@@ -15,6 +15,7 @@ module.exports = objectAssign({}, configShared, {
   target: "node",
   externals: {
     "react-native": "react-native", // our Reachability implementation needs to reference react-native.
+    "@react-native-community/netinfo": "@react-native-community/netinfo", // our Reachability implementation needs to reference react-native.
   },
   resolve: {
     modules: ['src/runtimes/react-native'],


### PR DESCRIPTION
## What does this PR do?
NetInfo was removed from react-native core in version 0.60. The functionality was moved to an external package [@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo). This PR updates pusher-js to use the new package.

The [@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo) is added as a build dep, for type checking.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
