### PR TITLE
Remove the useless Buffer polyfill from the build

### DIFF
--- a/webpack/config.shared.js
+++ b/webpack/config.shared.js
@@ -26,6 +26,12 @@ module.exports = {
       { test: /\.ts$/, loader: 'ts-loader' },
     ]
   },
+  node: {
+    // nacl uses Buffer on node.js but has a different code path for the browser.
+    // We don't need webpack to include a Buffer polyfill when seeing the usage,
+    // as it won't be used.
+    Buffer: false
+  },
   plugins: [
     new webpack.BannerPlugin({banner:  banner, raw: true}),
     new webpack.DefinePlugin({


### PR DESCRIPTION
tweetnacl works without Buffer when atob is available (which is the case
for web runtimes). So there is no reason to include the polyfill.

## What does this PR do?

[Description here]

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
