### PR TITLE
Optimize build

### DIFF
--- a/spec/javascripts/helpers/mocks.js
+++ b/spec/javascripts/helpers/mocks.js
@@ -64,14 +64,6 @@ var Mocks = {
     return request;
   },
 
-  getDependencies: function() {
-    return {
-      load: jasmine.createSpy("load"),
-      getRoot: jasmine.createSpy("getRoot"),
-      getPath: jasmine.createSpy("getPath")
-    };
-  },
-
   getJSONPSender: function() {
     return {
       send: jasmine.createSpy("send")

--- a/spec/javascripts/helpers/pusher_integration.js
+++ b/spec/javascripts/helpers/pusher_integration.js
@@ -1,0 +1,1 @@
+module.exports = require('./pusher_integration_class').default;

--- a/spec/javascripts/helpers/pusher_integration_class.ts
+++ b/spec/javascripts/helpers/pusher_integration_class.ts
@@ -1,7 +1,7 @@
 import Pusher from '../../../src/core/pusher';
 import {ScriptReceiverFactory} from '../../../src/runtimes/web/dom/script_receiver_factory';
 
-class PusherIntegration extends Pusher {
+export default class PusherIntegration extends Pusher {
 
   static Integration : any = {
     ScriptReceivers: new ScriptReceiverFactory(
@@ -10,5 +10,3 @@ class PusherIntegration extends Pusher {
     )}
 
 }
-
-module.exports = PusherIntegration;

--- a/spec/javascripts/integration/index.web.js
+++ b/spec/javascripts/integration/index.web.js
@@ -11,7 +11,7 @@ var TestEnv = require('testenv');
 
 var testConfigs = getTestConfigs();
 
-// We can ccess this 'env var' here because there's a webpack.DefinePlugin
+// We can access this 'env var' here because there's a webpack.DefinePlugin
 // overwriting this value with whatever is set at compile time
 if (process.env.MINIMAL_INTEGRATION_TESTS) {
   testConfigs = testConfigs.filter((config) => config.forceTLS && config.transport === "ws")

--- a/spec/javascripts/unit/core/connection/connection_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_spec.js
@@ -1,5 +1,5 @@
 var Connection = require('core/connection/connection').default;
-var Protocol = require('core/connection/protocol/protocol');
+var Protocol = require('core/connection/protocol/protocol').default;
 var Mocks = require("mocks");
 
 describe("Connection", function() {

--- a/spec/javascripts/unit/core/connection/handshake_spec.js
+++ b/spec/javascripts/unit/core/connection/handshake_spec.js
@@ -1,5 +1,5 @@
 var Handshake = require('core/connection/handshake').default;
-var Protocol = require('core/connection/protocol/protocol');
+var Protocol = require('core/connection/protocol/protocol').default;
 var Connection = require('core/connection/connection').default;
 var Mocks = require("mocks");
 

--- a/spec/javascripts/unit/core/connection/protocol_spec.js
+++ b/spec/javascripts/unit/core/connection/protocol_spec.js
@@ -1,4 +1,4 @@
-var Protocol = require('core/connection/protocol/protocol');
+var Protocol = require('core/connection/protocol/protocol').default;
 
 describe("Protocol", function() {
   describe("#decodeMessage", function() {

--- a/spec/javascripts/unit/core/transports/transport_connection_spec.js
+++ b/spec/javascripts/unit/core/transports/transport_connection_spec.js
@@ -3,7 +3,7 @@ var Mocks = require("mocks");
 var TransportConnection = require('core/transports/transport_connection').default;
 var Collections = require('core/utils/collections');
 var Timer = require('core/utils/timers').OneOffTimer;
-var DependenciesModule = require('dom/dependencies');
+var Dependencies = require('dom/dependencies').Dependencies;
 
 describe("TransportConnection", function() {
   function getTransport(hooks, key, options) {
@@ -21,13 +21,18 @@ describe("TransportConnection", function() {
   var socket;
   var timeline;
   var transport;
-  var Dependencies, _Dependencies;
+  var _DependenciesBackup;
 
   beforeEach(function() {
     if (TestEnv === "web") {
-      _Dependencies = DependenciesModule.Dependencies;
-      DependenciesModule.Dependencies = Mocks.getDependencies();
-      Dependencies = DependenciesModule.Dependencies;
+      _DependenciesBackup = {
+        load: Dependencies.load,
+        getRoot: Dependencies.getRoot,
+        getPath: Dependencies.getPath
+      }
+      Dependencies.load = jasmine.createSpy("load")
+      Dependencies.getRoot = jasmine.createSpy("getRoot")
+      Dependencies.getPath = jasmine.createSpy("getPath")
     }
 
     timeline = Mocks.getTimeline();
@@ -53,7 +58,9 @@ describe("TransportConnection", function() {
 
   afterEach(function(){
     if (TestEnv === "web") {
-      DependenciesModule.Dependencies = _Dependencies;
+      Dependencies.load = _DependenciesBackup.load
+      Dependencies.getRoot = _DependenciesBackup.getRoot
+      Dependencies.getPath = _DependenciesBackup.getPath
     }
   });
 

--- a/src/core/connection/connection.ts
+++ b/src/core/connection/connection.ts
@@ -1,6 +1,6 @@
 import * as Collections from '../utils/collections';
 import {default as EventsDispatcher} from '../events/dispatcher';
-import * as Protocol from './protocol/protocol';
+import Protocol from './protocol/protocol';
 import {PusherEvent} from './protocol/message-types';
 import Logger from '../logger';
 import TransportConnection from "../transports/transport_connection";

--- a/src/core/connection/handshake/index.ts
+++ b/src/core/connection/handshake/index.ts
@@ -1,6 +1,6 @@
 import Util from '../../util';
 import * as Collections from '../../utils/collections';
-import * as Protocol from '../protocol/protocol';
+import Protocol from '../protocol/protocol';
 import Connection from '../connection';
 import TransportConnection from "../../transports/transport_connection";
 import HandshakePayload from './handshake_payload';

--- a/src/core/connection/protocol/protocol.ts
+++ b/src/core/connection/protocol/protocol.ts
@@ -4,146 +4,151 @@ import {PusherEvent} from './message-types';
  * Provides functions for handling Pusher protocol-specific messages.
  */
 
-/**
- * Decodes a message in a Pusher format.
- *
- * The MessageEvent we receive from the transport should contain a pusher event
- * (https://pusher.com/docs/pusher_protocol#events) serialized as JSON in the
- * data field
- *
- * The pusher event may contain a data field too, and it may also be
- * serialised as JSON
- *
- * Throws errors when messages are not parse'able.
- *
- * @param  {MessageEvent} messageEvent
- * @return {PusherEvent}
- */
-export var decodeMessage = function(messageEvent : MessageEvent) : PusherEvent {
-  try {
-    var messageData = JSON.parse(messageEvent.data);
-    var pusherEventData = messageData.data;
-    if (typeof pusherEventData === 'string') {
-      try {
-        pusherEventData = JSON.parse(messageData.data)
-      } catch (e) {}
+const Protocol = {
+  /**
+   * Decodes a message in a Pusher format.
+   *
+   * The MessageEvent we receive from the transport should contain a pusher event
+   * (https://pusher.com/docs/pusher_protocol#events) serialized as JSON in the
+   * data field
+   *
+   * The pusher event may contain a data field too, and it may also be
+   * serialised as JSON
+   *
+   * Throws errors when messages are not parse'able.
+   *
+   * @param  {MessageEvent} messageEvent
+   * @return {PusherEvent}
+   */
+  decodeMessage: function(messageEvent : MessageEvent) : PusherEvent {
+    try {
+      var messageData = JSON.parse(messageEvent.data);
+      var pusherEventData = messageData.data;
+      if (typeof pusherEventData === 'string') {
+        try {
+          pusherEventData = JSON.parse(messageData.data)
+        } catch (e) {}
+      }
+      var pusherEvent: PusherEvent = {
+        event: messageData.event,
+        channel: messageData.channel,
+        data: pusherEventData,
+      }
+      if (messageData.user_id) {
+        pusherEvent.user_id = messageData.user_id
+      }
+      return pusherEvent;
+    } catch (e) {
+      throw { type: 'MessageParseError', error: e, data: messageEvent.data};
     }
-    var pusherEvent: PusherEvent = {
-      event: messageData.event,
-      channel: messageData.channel,
-      data: pusherEventData,
+  },
+
+  /**
+   * Encodes a message to be sent.
+   *
+   * @param  {PusherEvent} event
+   * @return {String}
+   */
+  encodeMessage: function(event : PusherEvent) : string {
+    return JSON.stringify(event);
+  },
+
+  /**
+   * Processes a handshake message and returns appropriate actions.
+   *
+   * Returns an object with an 'action' and other action-specific properties.
+   *
+   * There are three outcomes when calling this function. First is a successful
+   * connection attempt, when pusher:connection_established is received, which
+   * results in a 'connected' action with an 'id' property. When passed a
+   * pusher:error event, it returns a result with action appropriate to the
+   * close code and an error. Otherwise, it raises an exception.
+   *
+   * @param {String} message
+   * @result Object
+   */
+  processHandshake: function(messageEvent : MessageEvent) : Action {
+    var message = Protocol.decodeMessage(messageEvent);
+
+    if (message.event === "pusher:connection_established") {
+      if (!message.data.activity_timeout) {
+        throw "No activity timeout specified in handshake";
+      }
+      return {
+        action: "connected",
+        id: message.data.socket_id,
+        activityTimeout: message.data.activity_timeout * 1000
+      };
+    } else if (message.event === "pusher:error") {
+      // From protocol 6 close codes are sent only once, so this only
+      // happens when connection does not support close codes
+      return {
+        action: this.getCloseAction(message.data),
+        error: this.getCloseError(message.data)
+      };
+    } else {
+      throw "Invalid handshake";
     }
-    if (messageData.user_id) {
-      pusherEvent.user_id = messageData.user_id
-    }
-    return pusherEvent;
-  } catch (e) {
-    throw { type: 'MessageParseError', error: e, data: messageEvent.data};
-  }
-};
+  },
 
-/**
- * Encodes a message to be sent.
- *
- * @param  {PusherEvent} event
- * @return {String}
- */
-export var encodeMessage = function(event : PusherEvent) : string {
-  return JSON.stringify(event);
-};
-
-/** Processes a handshake message and returns appropriate actions.
- *
- * Returns an object with an 'action' and other action-specific properties.
- *
- * There are three outcomes when calling this function. First is a successful
- * connection attempt, when pusher:connection_established is received, which
- * results in a 'connected' action with an 'id' property. When passed a
- * pusher:error event, it returns a result with action appropriate to the
- * close code and an error. Otherwise, it raises an exception.
- *
- * @param {String} message
- * @result Object
- */
-export var processHandshake = function(messageEvent : MessageEvent) : Action {
-  var message = decodeMessage(messageEvent);
-
-  if (message.event === "pusher:connection_established") {
-    if (!message.data.activity_timeout) {
-      throw "No activity timeout specified in handshake";
-    }
-    return {
-      action: "connected",
-      id: message.data.socket_id,
-      activityTimeout: message.data.activity_timeout * 1000
-    };
-  } else if (message.event === "pusher:error") {
-    // From protocol 6 close codes are sent only once, so this only
-    // happens when connection does not support close codes
-    return {
-      action: this.getCloseAction(message.data),
-      error: this.getCloseError(message.data)
-    };
-  } else {
-    throw "Invalid handshake";
-  }
-};
-
-/**
- * Dispatches the close event and returns an appropriate action name.
- *
- * See:
- * 1. https://developer.mozilla.org/en-US/docs/WebSockets/WebSockets_reference/CloseEvent
- * 2. http://pusher.com/docs/pusher_protocol
- *
- * @param  {CloseEvent} closeEvent
- * @return {String} close action name
- */
-export var getCloseAction = function(closeEvent) : string {
-  if (closeEvent.code < 4000) {
-    // ignore 1000 CLOSE_NORMAL, 1001 CLOSE_GOING_AWAY,
-    //        1005 CLOSE_NO_STATUS, 1006 CLOSE_ABNORMAL
-    // ignore 1007...3999
-    // handle 1002 CLOSE_PROTOCOL_ERROR, 1003 CLOSE_UNSUPPORTED,
-    //        1004 CLOSE_TOO_LARGE
-    if (closeEvent.code >= 1002 && closeEvent.code <= 1004) {
+  /**
+   * Dispatches the close event and returns an appropriate action name.
+   *
+   * See:
+   * 1. https://developer.mozilla.org/en-US/docs/WebSockets/WebSockets_reference/CloseEvent
+   * 2. http://pusher.com/docs/pusher_protocol
+   *
+   * @param  {CloseEvent} closeEvent
+   * @return {String} close action name
+   */
+  getCloseAction: function(closeEvent) : string {
+    if (closeEvent.code < 4000) {
+      // ignore 1000 CLOSE_NORMAL, 1001 CLOSE_GOING_AWAY,
+      //        1005 CLOSE_NO_STATUS, 1006 CLOSE_ABNORMAL
+      // ignore 1007...3999
+      // handle 1002 CLOSE_PROTOCOL_ERROR, 1003 CLOSE_UNSUPPORTED,
+      //        1004 CLOSE_TOO_LARGE
+      if (closeEvent.code >= 1002 && closeEvent.code <= 1004) {
+        return "backoff";
+      } else {
+        return null;
+      }
+    } else if (closeEvent.code === 4000) {
+      return "tls_only";
+    } else if (closeEvent.code < 4100) {
+      return "refused";
+    } else if (closeEvent.code < 4200) {
       return "backoff";
+    } else if (closeEvent.code < 4300) {
+      return "retry";
+    } else {
+      // unknown error
+      return "refused";
+    }
+  },
+
+  /**
+   * Returns an error or null basing on the close event.
+   *
+   * Null is returned when connection was closed cleanly. Otherwise, an object
+   * with error details is returned.
+   *
+   * @param  {CloseEvent} closeEvent
+   * @return {Object} error object
+   */
+  getCloseError: function(closeEvent) : any {
+    if (closeEvent.code !== 1000 && closeEvent.code !== 1001) {
+      return {
+        type: 'PusherError',
+        data: {
+          code: closeEvent.code,
+          message: closeEvent.reason || closeEvent.message
+        }
+      };
     } else {
       return null;
     }
-  } else if (closeEvent.code === 4000) {
-    return "tls_only";
-  } else if (closeEvent.code < 4100) {
-    return "refused";
-  } else if (closeEvent.code < 4200) {
-    return "backoff";
-  } else if (closeEvent.code < 4300) {
-    return "retry";
-  } else {
-    // unknown error
-    return "refused";
   }
 };
 
-/**
- * Returns an error or null basing on the close event.
- *
- * Null is returned when connection was closed cleanly. Otherwise, an object
- * with error details is returned.
- *
- * @param  {CloseEvent} closeEvent
- * @return {Object} error object
- */
-export var getCloseError = function(closeEvent) : any {
-  if (closeEvent.code !== 1000 && closeEvent.code !== 1001) {
-    return {
-      type: 'PusherError',
-      data: {
-        code: closeEvent.code,
-        message: closeEvent.reason || closeEvent.message
-      }
-    };
-  } else {
-    return null;
-  }
-};
+export default Protocol;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,4 +1,2 @@
-import Pusher from './pusher';
-
 // required so we don't have to do require('pusher').default etc.
-module.exports = Pusher;
+module.exports = require('./pusher').default;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
-    "module": "commonjs",
+    "module": "es6",
     "declaration": false,
     "target": "es3",
     "removeComments": true,


### PR DESCRIPTION
Duplicate of #370 to run the build in CI with browserstack credentials

## What does this PR do?


This optimize the build to reduce the bundle size:

- it uses ES module as the output of Typescript (and so the input of webpack optimizations), as some of the most important optimizations performed by webpack are applied only on ES modules (see https://webpack.js.org/plugins/module-concatenation-plugin/)
- ~~it removes the useless Buffer polyfill injected by webpack due to tweetnacl using it (as it is using it only in node.js environments and has a different code path for the browser)~~ now extracted to #375

Here are the size of files for the web bundles (using `ls -shS1 dist/web/`, and keeping only the pusher files as sockjs and json2 are irrelevant for this PR):

before:
```
272K pusher.js
128K pusher.min.js
```

after first optimization (TS modules):

```
260K pusher.js
124K pusher.min.js
```

after both optimizations:
```
208K pusher.js
100K pusher.min.js
```