### PR TITLE
Update net_info.ts

### DIFF
--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -18,7 +18,7 @@ export class NetInfo extends EventsDispatcher implements Reachability {
       this.online = hasOnlineConnectionState(connectionState);
     });
 
-    NativeNetInfo.addEventListener('connectionChange', (connectionState)=>{
+    NativeNetInfo.addEventListener(connectionState => {
       var isNowOnline = hasOnlineConnectionState(connectionState);
 
       // React Native counts the switch from Wi-Fi to Cellular


### PR DESCRIPTION
Source: https://github.com/react-native-community/react-native-netinfo/issues/123

This should get rid of Deprecation warning (https://github.com/pusher/pusher-js/issues/382)
