### PR TITLE
Use new netinfo api

### DIFF
--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -14,7 +14,7 @@ export class NetInfo extends EventsDispatcher implements Reachability {
     super();
     this.online = true;
 
-    NativeNetInfo.getConnectionInfo().then(connectionState => {
+    NativeNetInfo.fetch().then(connectionState => {
       this.online = hasOnlineConnectionState(connectionState);
     });
 

--- a/src/runtimes/react-native/net_info.ts
+++ b/src/runtimes/react-native/net_info.ts
@@ -18,7 +18,7 @@ export class NetInfo extends EventsDispatcher implements Reachability {
       this.online = hasOnlineConnectionState(connectionState);
     });
 
-    NativeNetInfo.addEventListener('connectionChange', (connectionState)=>{
+    NativeNetInfo.addEventListener(connectionState => {
       var isNowOnline = hasOnlineConnectionState(connectionState);
 
       // React Native counts the switch from Wi-Fi to Cellular


### PR DESCRIPTION
## What does this PR do?

Uses the new API for @react-native-community/netinfo. We made the switch to @react-native-community/netinfo package in version 5.0.0 but we continued to use the old API.

This makes the minor changes required to use the new API, the functionality should be identical.

## Checklist

- [-] All new functionality has tests.
- [-] All tests are passing.
- [-] New or changed API methods have been documented.
