### PR TITLE
Replace `encrypted` with `forceTLS` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,14 +262,14 @@ const socket = new Pusher(APP_KEY, {
 });
 ```
 
-Note: if you intend to use secure websockets, or `wss`, you can not simply specify `wss` in `enabledTransports`, you must specify `ws` in `enabledTransports` as well as set the `encrypted` option to `true`.
+Note: if you intend to use secure websockets, or `wss`, you can not simply specify `wss` in `enabledTransports`, you must specify `ws` in `enabledTransports` as well as set the `forceTLS` option to `true`.
 
 ```js
 // Only use secure WebSockets
 const socket = new Pusher(APP_KEY, {
   cluster: APP_CLUSTER,
   enabledTransports: ['ws'],
-  encrypted: true
+  forceTLS: true
 });
 ```
 


### PR DESCRIPTION
Some old docs with `encrypted` made it into the readme

## What does this PR do?

[Description here]

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
