### PR TITLE
Error logging improvements

### DIFF
--- a/spec/javascripts/unit/core/channels/encrypted_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/encrypted_channel_spec.js
@@ -288,7 +288,7 @@ describe("EncryptedChannel", function() {
             nonce: nonceBase64,
             ciphertext: tweetNaclUtil.encodeBase64('garbage-ciphertext')
           };
-          spyOn(Logger, "warn");
+          spyOn(Logger, "error");
           channel.handleEvent({
             event: "something",
             data: encryptedPayload
@@ -297,7 +297,7 @@ describe("EncryptedChannel", function() {
             shared_secret: newSecretBase64,
             foo: "bar"
           });
-          expect(Logger.warn).toHaveBeenCalledWith(
+          expect(Logger.error).toHaveBeenCalledWith(
             "Failed to decrypt event with new key. Dropping encrypted event"
           );
         });
@@ -307,13 +307,13 @@ describe("EncryptedChannel", function() {
             nonce: nonceBase64,
             ciphertext: newTestEncrypt(payload)
           };
-          spyOn(Logger, "warn");
+          spyOn(Logger, "error");
           channel.handleEvent({
             event: "something",
             data: encryptedPayload
           });
           authorizer._callback(true, "ERROR");
-          expect(Logger.warn).toHaveBeenCalledWith(
+          expect(Logger.error).toHaveBeenCalledWith(
             "Failed to make a request to the authEndpoint: ERROR. Unable to fetch new key, so dropping encrypted event"
           );
         });

--- a/spec/javascripts/unit/core/logger_spec.js
+++ b/spec/javascripts/unit/core/logger_spec.js
@@ -6,15 +6,19 @@ describe("Logger", function() {
 
   var _nativeConsoleLog;
   var _nativeConsoleWarn;
+  var _nativeConsoleError;
   var _consoleLogCalls;
   var _consoleWarnCalls;
+  var _consoleErrorCalls;
 
   beforeEach(function() {
     _consoleLogCalls = [];
     _consoleWarnCalls = [];
+    _consoleErrorCalls = [];
 
     _nativeConsoleLog = global.console.log;
     _nativeConsoleWarn = global.console.warn;
+    _nativeConsoleError = global.console.error;
 
     global.console.log = function() {
       _consoleLogCalls.push(arguments);
@@ -22,11 +26,15 @@ describe("Logger", function() {
     global.console.warn = function() {
       _consoleWarnCalls.push(arguments);
     };
+    global.console.error = function() {
+      _consoleErrorCalls.push(arguments);
+    };
   });
 
   afterEach(function() {
     global.console.log = _nativeConsoleLog;
     global.console.warn = _nativeConsoleWarn;
+    global.console.error = _nativeConsoleError;
   });
 
   it("logToConsole should be disabled by default", function() {
@@ -36,18 +44,45 @@ describe("Logger", function() {
   it("should not log to the console if logToConsole set to false", function() {
     Logger.debug("test", "this is a test");
     Logger.warn("test", "this is a test");
+    Logger.error("test", "this is a test");
 
     expect(_consoleLogCalls.length).toEqual(0);
     expect(_consoleWarnCalls.length).toEqual(0);
+    expect(_consoleErrorCalls.length).toEqual(0);
   });
 
   it("should log to the console if logToConsole set to true", function() {
     Pusher.logToConsole = true;
     Logger.debug("test", "this is a test");
     Logger.warn("test", "this is a test");
+    Logger.error("test", "this is a test");
 
     expect(_consoleLogCalls.length).toEqual(1);
     expect(_consoleWarnCalls.length).toEqual(1);
+    expect(_consoleErrorCalls.length).toEqual(1);
+  });
+
+  it("should fallback to warn if error not available when logging error", function() {
+    Pusher.logToConsole = true;
+    global.console.error = undefined;
+
+    Logger.error("test", "this is a test");
+
+    expect(_consoleLogCalls.length).toEqual(0);
+    expect(_consoleWarnCalls.length).toEqual(1);
+    expect(_consoleErrorCalls.length).toEqual(0);
+  });
+
+  it("should fallback to log if error and warn not available when logging error", function() {
+    Pusher.logToConsole = true;
+    global.console.error = undefined;
+    global.console.warn = undefined;
+
+    Logger.error("test", "this is a test");
+
+    expect(_consoleLogCalls.length).toEqual(1);
+    expect(_consoleWarnCalls.length).toEqual(0);
+    expect(_consoleErrorCalls.length).toEqual(0);
   });
 
   it("should fallback to log if warn not available when logging warn", function() {
@@ -58,5 +93,6 @@ describe("Logger", function() {
 
     expect(_consoleLogCalls.length).toEqual(1);
     expect(_consoleWarnCalls.length).toEqual(0);
+    expect(_consoleErrorCalls.length).toEqual(0);
   });
 });

--- a/spec/javascripts/unit/core/logger_spec.js
+++ b/spec/javascripts/unit/core/logger_spec.js
@@ -2,38 +2,61 @@ var Pusher = require('core/pusher').default;
 var Logger = require('core/logger').default;
 var global = Function("return this")();
 
-describe("Pusher.logToConsole", function() {
+describe("Logger", function() {
 
   var _nativeConsoleLog;
+  var _nativeConsoleWarn;
   var _consoleLogCalls;
+  var _consoleWarnCalls;
 
   beforeEach(function() {
     _consoleLogCalls = [];
+    _consoleWarnCalls = [];
 
     _nativeConsoleLog = global.console.log;
+    _nativeConsoleWarn = global.console.warn;
+
     global.console.log = function() {
       _consoleLogCalls.push(arguments);
+    };
+    global.console.warn = function() {
+      _consoleWarnCalls.push(arguments);
     };
   });
 
   afterEach(function() {
     global.console.log = _nativeConsoleLog;
+    global.console.warn = _nativeConsoleWarn;
   });
 
-  it("should be disabled by default", function() {
+  it("logToConsole should be disabled by default", function() {
     expect(Pusher.logToConsole).toEqual(false);
   });
 
-  it("should not log to the console if set to false", function() {
+  it("should not log to the console if logToConsole set to false", function() {
+    Logger.debug("test", "this is a test");
     Logger.warn("test", "this is a test");
 
     expect(_consoleLogCalls.length).toEqual(0);
+    expect(_consoleWarnCalls.length).toEqual(0);
   });
 
-  it("should log to the console if set to true", function() {
+  it("should log to the console if logToConsole set to true", function() {
     Pusher.logToConsole = true;
+    Logger.debug("test", "this is a test");
     Logger.warn("test", "this is a test");
 
-    expect(_consoleLogCalls.length).toBeGreaterThan(0);
+    expect(_consoleLogCalls.length).toEqual(1);
+    expect(_consoleWarnCalls.length).toEqual(1);
+  });
+
+  it("should fallback to log if warn not available when logging warn", function() {
+    Pusher.logToConsole = true;
+    global.console.warn = undefined;
+
+    Logger.warn("test", "this is a test");
+
+    expect(_consoleLogCalls.length).toEqual(1);
+    expect(_consoleWarnCalls.length).toEqual(0);
   });
 });

--- a/spec/javascripts/unit/core/logger_spec.js
+++ b/spec/javascripts/unit/core/logger_spec.js
@@ -37,62 +37,96 @@ describe("Logger", function() {
     global.console.error = _nativeConsoleError;
   });
 
-  it("logToConsole should be disabled by default", function() {
-    expect(Pusher.logToConsole).toEqual(false);
+  // logToConsole should be disabled by default
+  describe("with logToConsole == false", function() {
+    it("should not log to the console", function() {
+      Logger.debug("test", "this is a test");
+
+      expect(_consoleLogCalls.length).toEqual(0);
+      expect(_consoleWarnCalls.length).toEqual(0);
+      expect(_consoleErrorCalls.length).toEqual(0);
+    });
+
+    it("should not warn to the console", function() {
+      Logger.warn("test", "this is a test");
+
+      expect(_consoleLogCalls.length).toEqual(0);
+      expect(_consoleWarnCalls.length).toEqual(0);
+      expect(_consoleErrorCalls.length).toEqual(0);
+    });
+
+    it("should not error to the console", function() {
+      Logger.error("test", "this is a test");
+
+      expect(_consoleLogCalls.length).toEqual(0);
+      expect(_consoleWarnCalls.length).toEqual(0);
+      expect(_consoleErrorCalls.length).toEqual(0);
+    });
   });
 
-  it("should not log to the console if logToConsole set to false", function() {
-    Logger.debug("test", "this is a test");
-    Logger.warn("test", "this is a test");
-    Logger.error("test", "this is a test");
+  describe("with logToConsole == true", function() {
+    beforeEach(function() {
+      Pusher.logToConsole = true;
+    })
 
-    expect(_consoleLogCalls.length).toEqual(0);
-    expect(_consoleWarnCalls.length).toEqual(0);
-    expect(_consoleErrorCalls.length).toEqual(0);
-  });
+    it("should log to the console", function() {
+      Logger.debug("test", "this is a test");
 
-  it("should log to the console if logToConsole set to true", function() {
-    Pusher.logToConsole = true;
-    Logger.debug("test", "this is a test");
-    Logger.warn("test", "this is a test");
-    Logger.error("test", "this is a test");
+      expect(_consoleLogCalls.length).toEqual(1);
+      expect(_consoleWarnCalls.length).toEqual(0);
+      expect(_consoleErrorCalls.length).toEqual(0);
+    });
 
-    expect(_consoleLogCalls.length).toEqual(1);
-    expect(_consoleWarnCalls.length).toEqual(1);
-    expect(_consoleErrorCalls.length).toEqual(1);
-  });
+    it("should warn to the console", function() {
+      Logger.warn("test", "this is a test");
 
-  it("should fallback to warn if error not available when logging error", function() {
-    Pusher.logToConsole = true;
-    global.console.error = undefined;
+      expect(_consoleLogCalls.length).toEqual(0);
+      expect(_consoleWarnCalls.length).toEqual(1);
+      expect(_consoleErrorCalls.length).toEqual(0);
+    });
 
-    Logger.error("test", "this is a test");
+    it("should error to the console", function() {
+      Logger.error("test", "this is a test");
 
-    expect(_consoleLogCalls.length).toEqual(0);
-    expect(_consoleWarnCalls.length).toEqual(1);
-    expect(_consoleErrorCalls.length).toEqual(0);
-  });
+      expect(_consoleLogCalls.length).toEqual(0);
+      expect(_consoleWarnCalls.length).toEqual(0);
+      expect(_consoleErrorCalls.length).toEqual(1);
+    });
 
-  it("should fallback to log if error and warn not available when logging error", function() {
-    Pusher.logToConsole = true;
-    global.console.error = undefined;
-    global.console.warn = undefined;
+    describe("with console.error == undefined", function() {
+      beforeEach(function() {
+        global.console.error = undefined;
+      })
 
-    Logger.error("test", "this is a test");
+      it("should fallback error logs to warn", function() {
+        Logger.error("test", "this is a test");
+    
+        expect(_consoleLogCalls.length).toEqual(0);
+        expect(_consoleWarnCalls.length).toEqual(1);
+        expect(_consoleErrorCalls.length).toEqual(0);
+      });
 
-    expect(_consoleLogCalls.length).toEqual(1);
-    expect(_consoleWarnCalls.length).toEqual(0);
-    expect(_consoleErrorCalls.length).toEqual(0);
-  });
+      describe("with console.warn == undefined", function() {
+        beforeEach(function() {
+          global.console.warn = undefined;
+        })
 
-  it("should fallback to log if warn not available when logging warn", function() {
-    Pusher.logToConsole = true;
-    global.console.warn = undefined;
+        it("should fallback warn logs to log", function() {
+          Logger.warn("test", "this is a test");
+      
+          expect(_consoleLogCalls.length).toEqual(1);
+          expect(_consoleWarnCalls.length).toEqual(0);
+          expect(_consoleErrorCalls.length).toEqual(0);
+        });
 
-    Logger.warn("test", "this is a test");
-
-    expect(_consoleLogCalls.length).toEqual(1);
-    expect(_consoleWarnCalls.length).toEqual(0);
-    expect(_consoleErrorCalls.length).toEqual(0);
+        it("should fallback error logs to log", function() {
+          Logger.error("test", "this is a test");
+      
+          expect(_consoleLogCalls.length).toEqual(1);
+          expect(_consoleWarnCalls.length).toEqual(0);
+          expect(_consoleErrorCalls.length).toEqual(0);
+        });
+      });
+    });
   });
 });

--- a/spec/javascripts/unit/core/pusher_authorizer_spec.js
+++ b/spec/javascripts/unit/core/pusher_authorizer_spec.js
@@ -146,7 +146,7 @@ if (TestEnv !== "worker") {
       expect(callback.calls.length).toEqual(1);
       expect(callback).toHaveBeenCalledWith(
         true,
-        "JSON returned from webapp was invalid, yet status code was 200. " +
+        "JSON returned from auth endpoint was invalid, yet status code was 200. " +
           "Data was: " +
           invalidJSON
       );

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -470,7 +470,7 @@ describe("Pusher", function() {
 
       spyOn(Logger, "warn");
       pusher.connection.emit("error", "something");
-      expect(Logger.warn).toHaveBeenCalledWith("Error", "something");
+      expect(Logger.warn).toHaveBeenCalledWith("something");
     });
   });
 

--- a/spec/javascripts/unit/web/pusher_authorizer_spec.js
+++ b/spec/javascripts/unit/web/pusher_authorizer_spec.js
@@ -31,7 +31,6 @@ describe("JSONP Authorizer", function() {
     authorizer.authorize("1.23", function() {});
 
     expect(Logger.warn).toHaveBeenCalledWith(
-      "Warn",
       "To send headers with the auth request, you must use AJAX, rather than JSONP."
     );
   });

--- a/spec/javascripts/unit/worker/pusher_authorizer_spec.js
+++ b/spec/javascripts/unit/worker/pusher_authorizer_spec.js
@@ -102,7 +102,7 @@ describe("Fetch Authorizer", function(){
       expect(callback.calls.length).toEqual(1);
       expect(callback).toHaveBeenCalledWith(
         true,
-        "JSON returned from webapp was invalid, yet status code was 200. " +
+        "JSON returned from auth endpoint was invalid, yet status code was 200. " +
           "Data was: " +
           invalidJSON
       );

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -96,7 +96,8 @@ export default class Channel extends EventsDispatcher {
     this.subscriptionCancelled = false;
     this.authorize(this.pusher.connection.socket_id, (error, data)=> {
       if (error) {
-        this.emit('pusher:subscription_error', data)
+        Logger.warn('Error', data);
+        this.emit('pusher:subscription_error', data);
       } else {
         this.pusher.send_event('pusher:subscribe', {
           auth: data.auth,

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -96,7 +96,7 @@ export default class Channel extends EventsDispatcher {
     this.subscriptionCancelled = false;
     this.authorize(this.pusher.connection.socket_id, (error, data)=> {
       if (error) {
-        Logger.error('Error', data);
+        Logger.error(data);
         this.emit('pusher:subscription_error', data);
       } else {
         this.pusher.send_event('pusher:subscribe', {

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -96,6 +96,9 @@ export default class Channel extends EventsDispatcher {
     this.subscriptionCancelled = false;
     this.authorize(this.pusher.connection.socket_id, (error, data)=> {
       if (error) {
+        // Why not bind to 'pusher:subscription_error' a level up, and log there?
+        // Binding to this event would cause the warning about no callbacks being
+        // bound (see constructor) to be suppressed, that's not what we want.
         Logger.error(data);
         this.emit('pusher:subscription_error', data);
       } else {

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -96,7 +96,7 @@ export default class Channel extends EventsDispatcher {
     this.subscriptionCancelled = false;
     this.authorize(this.pusher.connection.socket_id, (error, data)=> {
       if (error) {
-        Logger.warn('Error', data);
+        Logger.error('Error', data);
         this.emit('pusher:subscription_error', data);
       } else {
         this.pusher.send_event('pusher:subscribe', {

--- a/src/core/channels/encrypted_channel.ts
+++ b/src/core/channels/encrypted_channel.ts
@@ -32,7 +32,7 @@ export default class EncryptedChannel extends PrivateChannel {
       if (!sharedSecret) {
         let errorMsg = `No shared_secret key in auth payload for encrypted channel: ${this.name}`;
         callback(true, errorMsg);
-        Logger.error(`Error: ${errorMsg}`);
+        Logger.error(errorMsg);
         return;
       }
       this.key = decodeBase64(sharedSecret);

--- a/src/core/channels/encrypted_channel.ts
+++ b/src/core/channels/encrypted_channel.ts
@@ -32,7 +32,7 @@ export default class EncryptedChannel extends PrivateChannel {
       if (!sharedSecret) {
         let errorMsg = `No shared_secret key in auth payload for encrypted channel: ${this.name}`;
         callback(true, errorMsg);
-        Logger.warn(`Error: ${errorMsg}`);
+        Logger.error(`Error: ${errorMsg}`);
         return;
       }
       this.key = decodeBase64(sharedSecret);
@@ -67,17 +67,17 @@ export default class EncryptedChannel extends PrivateChannel {
       return;
     }
     if (!data.ciphertext || !data.nonce) {
-      Logger.warn('Unexpected format for encrypted event, expected object with `ciphertext` and `nonce` fields, got: ' + data);
+      Logger.error('Unexpected format for encrypted event, expected object with `ciphertext` and `nonce` fields, got: ' + data);
       return;
     }
     let cipherText = decodeBase64(data.ciphertext);
     if (cipherText.length < secretbox.overheadLength) {
-      Logger.warn(`Expected encrypted event ciphertext length to be ${secretbox.overheadLength}, got: ${cipherText.length}`);
+      Logger.error(`Expected encrypted event ciphertext length to be ${secretbox.overheadLength}, got: ${cipherText.length}`);
       return;
     }
     let nonce = decodeBase64(data.nonce);
     if (nonce.length < secretbox.nonceLength) {
-      Logger.warn(`Expected encrypted event nonce length to be ${secretbox.nonceLength}, got: ${nonce.length}`);
+      Logger.error(`Expected encrypted event nonce length to be ${secretbox.nonceLength}, got: ${nonce.length}`);
       return;
     }
 
@@ -88,12 +88,12 @@ export default class EncryptedChannel extends PrivateChannel {
       // If this fails, a new key will be requested when a new message is received
       this.authorize(this.pusher.connection.socket_id, (error, authData) => {
         if (error) {
-          Logger.warn(`Failed to make a request to the authEndpoint: ${authData}. Unable to fetch new key, so dropping encrypted event`);
+          Logger.error(`Failed to make a request to the authEndpoint: ${authData}. Unable to fetch new key, so dropping encrypted event`);
           return;
         }
         bytes = secretbox.open(cipherText, nonce, this.key);
         if (bytes === null) {
-          Logger.warn(`Failed to decrypt event with new key. Dropping encrypted event`);
+          Logger.error(`Failed to decrypt event with new key. Dropping encrypted event`);
           return;
         }
         this.emitJSON(event, encodeUTF8(bytes));

--- a/src/core/channels/encrypted_channel.ts
+++ b/src/core/channels/encrypted_channel.ts
@@ -32,7 +32,6 @@ export default class EncryptedChannel extends PrivateChannel {
       if (!sharedSecret) {
         let errorMsg = `No shared_secret key in auth payload for encrypted channel: ${this.name}`;
         callback(true, errorMsg);
-        Logger.error(errorMsg);
         return;
       }
       this.key = decodeBase64(sharedSecret);

--- a/src/core/channels/presence_channel.ts
+++ b/src/core/channels/presence_channel.ts
@@ -29,7 +29,7 @@ export default class PresenceChannel extends PrivateChannel {
       if (!error) {
         if (authData.channel_data === undefined) {
           let suffix = UrlStore.buildLogSuffix("authenticationEndpoint");
-          Logger.warn(
+          Logger.error(
             `Invalid auth response for channel '${this.name}',` +
             `expected 'channel_data' field. ${suffix}`
           );

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,13 +1,13 @@
 import { stringify } from './utils/collections';
 import Pusher from './pusher';
 
-function globalLog(message) {
+function globalLog(message: string) {
   if (global.console && global.console.log) {
     global.console.log(message);
   }
 }
 
-function globalLogWarn(message) {
+function globalLogWarn(message: string) {
   if (global.console && global.console.warn) {
     global.console.warn(message);
   } else {
@@ -15,7 +15,7 @@ function globalLogWarn(message) {
   }
 }
 
-function globalLogError(message) {
+function globalLogError(message: string) {
   if (global.console && global.console.error) {
     global.console.error(message);
   } else {
@@ -23,7 +23,10 @@ function globalLogError(message) {
   }
 }
 
-function log(defaultLoggingFunction, ...args: any[]) {
+function log(
+  defaultLoggingFunction: (message: string) => void,
+  ...args: any[]
+) {
   var message = stringify.apply(this, arguments);
   if (Pusher.log) {
     Pusher.log(message);

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,50 +1,53 @@
 import { stringify } from './utils/collections';
 import Pusher from './pusher';
 
-function globalLog(message: string) {
-  if (global.console && global.console.log) {
-    global.console.log(message);
-  }
-}
-
-function globalLogWarn(message: string) {
-  if (global.console && global.console.warn) {
-    global.console.warn(message);
-  } else {
-    globalLog(message);
-  }
-}
-
-function globalLogError(message: string) {
-  if (global.console && global.console.error) {
-    global.console.error(message);
-  } else {
-    globalLogWarn(message);
-  }
-}
-
-function log(
-  defaultLoggingFunction: (message: string) => void,
-  ...args: any[]
-) {
-  var message = stringify.apply(this, arguments);
-  if (Pusher.log) {
-    Pusher.log(message);
-  } else if (Pusher.logToConsole) {
-    defaultLoggingFunction(message);
-  }
-}
-
-const Logger = {
+class Logger {
   debug(...args: any[]) {
-    log(globalLog, args);
-  },
-  warn(...args: any[]) {
-    log(globalLogWarn, args);
-  },
-  error(...args: any[]) {
-    log(globalLogError, args);
+    this.log(this.globalLog, args);
   }
-};
 
-export default Logger;
+  warn(...args: any[]) {
+    this.log(this.globalLogWarn, args);
+  }
+
+  error(...args: any[]) {
+    this.log(this.globalLogError, args);
+  }
+
+  private globalLog = (message: string) => {
+    if (global.console && global.console.log) {
+      global.console.log(message);
+    }
+  };
+
+  private globalLogWarn(message: string) {
+    if (global.console && global.console.warn) {
+      global.console.warn(message);
+    } else {
+      this.globalLog(message);
+    }
+  }
+
+  private globalLogError(message: string) {
+    if (global.console && global.console.error) {
+      global.console.error(message);
+    } else {
+      this.globalLogWarn(message);
+    }
+  }
+
+  private log(
+    defaultLoggingFunction: (message: string) => void,
+    ...args: any[]
+  ) {
+    var message = stringify.apply(this, arguments);
+    if (Pusher.log) {
+      Pusher.log(message);
+    } else if (Pusher.logToConsole) {
+      const log = defaultLoggingFunction.bind(this);
+      log(message);
+    }
+  }
+}
+
+export default new Logger();

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,42 +1,46 @@
 import { stringify } from './utils/collections';
 import Pusher from './pusher';
 
+function globalLog(message) {
+  if (global.console && global.console.log) {
+    global.console.log(message);
+  }
+}
+
+function globalLogWarn(message) {
+  if (global.console && global.console.warn) {
+    global.console.warn(message);
+  } else {
+    globalLog(message);
+  }
+}
+
+function globalLogError(message) {
+  if (global.console && global.console.error) {
+    global.console.error(message);
+  } else {
+    globalLogWarn(message);
+  }
+}
+
+function log(defaultLoggingFunction, ...args: any[]) {
+  var message = stringify.apply(this, arguments);
+  if (Pusher.log) {
+    Pusher.log(message);
+  } else if (Pusher.logToConsole) {
+    defaultLoggingFunction(message);
+  }
+}
+
 const Logger = {
   debug(...args: any[]) {
-    var message = stringify.apply(this, arguments);
-    if (Pusher.log) {
-      Pusher.log(message);
-    } else if (Pusher.logToConsole && global.console) {
-      if (global.console.log) {
-        global.console.log(message);
-      }
-    }
+    log(globalLog, args);
   },
   warn(...args: any[]) {
-    var message = stringify.apply(this, arguments);
-    if (Pusher.log) {
-      Pusher.log(message);
-    } else if (Pusher.logToConsole && global.console) {
-      if (global.console.warn) {
-        global.console.warn(message);
-      } else if (global.console.log) {
-        global.console.log(message);
-      }
-    }
+    log(globalLogWarn, args);
   },
   error(...args: any[]) {
-    var message = stringify.apply(this, arguments);
-    if (Pusher.log) {
-      Pusher.log(message);
-    } else if (Pusher.logToConsole && global.console) {
-      if (global.console.error) {
-        global.console.error(message);
-      } else if (global.console.warn) {
-        global.console.warn(message);
-      } else if (global.console.log) {
-        global.console.log(message);
-      }
-    }
+    log(globalLogError, args);
   }
 };
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -23,6 +23,20 @@ const Logger = {
         global.console.log(message);
       }
     }
+  },
+  error(...args: any[]) {
+    var message = stringify.apply(this, arguments);
+    if (Pusher.log) {
+      Pusher.log(message);
+    } else if (Pusher.logToConsole && global.console) {
+      if (global.console.error) {
+        global.console.error(message);
+      } else if (global.console.warn) {
+        global.console.warn(message);
+      } else if (global.console.log) {
+        global.console.log(message);
+      }
+    }
   }
 };
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -3,16 +3,20 @@ import Pusher from './pusher';
 
 const Logger = {
   debug(...args: any[]) {
-    if (!Pusher.log) {
-      return;
+    var message = stringify.apply(this, arguments);
+    if (Pusher.log) {
+      Pusher.log(message);
+    } else if (Pusher.logToConsole && global.console) {
+      if (global.console.log) {
+        global.console.log(message);
+      }
     }
-    Pusher.log(stringify.apply(this, arguments));
   },
   warn(...args: any[]) {
     var message = stringify.apply(this, arguments);
     if (Pusher.log) {
       Pusher.log(message);
-    } else if (global.console) {
+    } else if (Pusher.logToConsole && global.console) {
       if (global.console.warn) {
         global.console.warn(message);
       } else if (global.console.log) {

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -142,7 +142,7 @@ export default class Pusher {
       this.channels.disconnect();
     });
     this.connection.bind('error', err => {
-      Logger.warn('Error', err);
+      Logger.warn(err);
     });
 
     Pusher.instances.push(this);

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -38,11 +38,7 @@ export default class Pusher {
     }
   }
 
-  static log(message: any) {
-    if (Pusher.logToConsole && global.console && global.console.log) {
-      global.console.log(message);
-    }
-  }
+  static log: (message: any) => void;
 
   private static getClientFeatures(): string[] {
     return Collections.keys(

--- a/src/runtimes/isomorphic/auth/xhr_auth.ts
+++ b/src/runtimes/isomorphic/auth/xhr_auth.ts
@@ -36,7 +36,7 @@ var ajax : AuthTransport = function(context : AbstractRuntime, socketId, callbac
         }
       } else {
         var suffix = UrlStore.buildLogSuffix("authenticationEndpoint");
-        Logger.warn(
+        Logger.error(
           'Unable to retrieve auth string from auth endpoint - ' +
           `received status ${xhr.status} from ${self.options.authEndpoint}. ` +
           `Clients must be authenticated to join private or presence channels. ${suffix}`

--- a/src/runtimes/isomorphic/auth/xhr_auth.ts
+++ b/src/runtimes/isomorphic/auth/xhr_auth.ts
@@ -28,7 +28,7 @@ var ajax : AuthTransport = function(context : AbstractRuntime, socketId, callbac
           data = JSON.parse(xhr.responseText);
           parsed = true;
         } catch (e) {
-          callback(true, 'JSON returned from webapp was invalid, yet status code was 200. Data was: ' + xhr.responseText);
+          callback(true, 'JSON returned from auth endpoint was invalid, yet status code was 200. Data was: ' + xhr.responseText);
         }
 
         if (parsed) { // prevents double execution.

--- a/src/runtimes/web/auth/jsonp_auth.ts
+++ b/src/runtimes/web/auth/jsonp_auth.ts
@@ -6,7 +6,7 @@ import {AuthTransport} from 'core/auth/auth_transports';
 
 var jsonp : AuthTransport = function(context : Browser, socketId, callback){
   if(this.authOptions.headers !== undefined) {
-    Logger.warn("Warn", "To send headers with the auth request, you must use AJAX, rather than JSONP.");
+    Logger.warn('To send headers with the auth request, you must use AJAX, rather than JSONP.');
   }
 
   var callbackName = context.nextAuthCallbackID.toString();

--- a/src/runtimes/worker/auth/fetch_auth.ts
+++ b/src/runtimes/worker/auth/fetch_auth.ts
@@ -23,7 +23,7 @@ var fetchAuth : AuthTransport = function(context, socketId, callback){
     if (status === 200) {
       return response.text();
     } else {
-      Logger.warn("Couldn't get auth info from your auth endpoint", status);
+      Logger.error("Couldn't get auth info from your auth endpoint", status);
       throw status;
     }
   }).then((data)=>{
@@ -31,7 +31,7 @@ var fetchAuth : AuthTransport = function(context, socketId, callback){
       data = JSON.parse(data);
     } catch (e) {
       var message = 'JSON returned from auth endpoint was invalid, yet status code was 200. Data was: ' + data;
-      Logger.warn(message);
+      Logger.error(message);
       throw message;
     }
     callback(false, data);

--- a/src/runtimes/worker/auth/fetch_auth.ts
+++ b/src/runtimes/worker/auth/fetch_auth.ts
@@ -23,14 +23,14 @@ var fetchAuth : AuthTransport = function(context, socketId, callback){
     if (status === 200) {
       return response.text();
     } else {
-      Logger.warn("Couldn't get auth info from your webapp", status);
+      Logger.warn("Couldn't get auth info from your auth endpoint", status);
       throw status;
     }
   }).then((data)=>{
     try {
       data = JSON.parse(data);
     } catch (e) {
-      var message = 'JSON returned from webapp was invalid, yet status code was 200. Data was: ' + data;
+      var message = 'JSON returned from auth endpoint was invalid, yet status code was 200. Data was: ' + data;
       Logger.warn(message);
       throw message;
     }


### PR DESCRIPTION
## What does this PR do?

There were three objectives of this PR:


1. If the auth response body is not JSON and logToConsole is set, it should log an error (not just mention no callback is bound)
2. All calls to Logger.warn logs should use console.warn if no default logger is set
3. Extend Logger to include an error method that calls console.error. Error logs should be updated to use this.

I made a couple of other changes while I was at it. The commit messages should be self-explanatory.

There are a couple of points I'd like feedback on in particular:

1. Connection errors are logged at warning level. This is because expected conditions like disconnects are included here. However it also includes error like failure to decode websocket messages, which I think should ideally be logged as errors.
2. @leesio it would be good to get feedback on how I refactored the `Logger.ts` file. I wasn't to implement something like private methods, but I'm not sure this best way of doing this.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
