### PR TITLE
Use XHR for stats requests because JSONP sends cookies, resulting in ugly warnings

### DIFF
--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -12,18 +12,7 @@ var Runtime = require('runtime').default;
 
 describe("Pusher", function() {
   var _isReady, _instances, _logToConsole;
-
-  switch (TestEnv) {
-    case "worker":
-    case "node":
-      var timelineTransport = "xhr";
-      break;
-    case "web":
-      var timelineTransport = "jsonp";
-      break
-    default:
-      throw("Please specify the test environment as an external.")
-  }
+  var timelineTransport = "xhr";
 
   beforeEach(function() {
     _instances = Pusher.instances;

--- a/src/runtimes/isomorphic/timeline/xhr_timeline.ts
+++ b/src/runtimes/isomorphic/timeline/xhr_timeline.ts
@@ -21,16 +21,25 @@ var getAgent = function(sender : TimelineSender, useTLS : boolean) {
         let {status, responseText} = xhr;
         if (status !== 200) {
           Logger.debug(`TimelineSender Error: received ${status} from stats.pusher.com`);
+          if (callback) {
+            callback(`Error: received ${status} from stats.pusher.com`, null)
+          }
           return;
         }
 
+        var result;
         try {
-          var {host} = JSON.parse(responseText);
+          var result = JSON.parse(responseText);
         } catch(e) {
           Logger.debug(`TimelineSenderError: invalid response ${responseText}`);
+          return
         }
-        if (host) {
-          sender.host = host;
+
+        if (result && result.host) {
+          sender.host = result.host;
+        }
+        if (callback) {
+          callback(null, result)
         }
       }
     }

--- a/src/runtimes/web/runtime.ts
+++ b/src/runtimes/web/runtime.ts
@@ -9,7 +9,7 @@ import ScriptRequest from './dom/script_request';
 import JSONPRequest from './dom/jsonp_request';
 import * as Collections from 'core/utils/collections';
 import {ScriptReceivers} from './dom/script_receiver_factory';
-import jsonpTimeline from './timeline/jsonp_timeline';
+import xhrTimeline from '../isomorphic/timeline/xhr_timeline';
 import Transports from './transports/transports';
 import Ajax from "core/http/ajax";
 import {Network} from './net_info';
@@ -30,7 +30,11 @@ var Runtime : Browser = {
   transportConnectionInitializer,
   HTTPFactory,
 
-  TimelineTransport: jsonpTimeline,
+  // We don't use jsonpTimeline here, because the <script> tag unnecessarily 
+  // sends cookies in the request, resulting in an ugly warning in the console: 
+  // "A cookie associated with a cross-site resource at http://pusher.com/ 
+  // was set without the `SameSite` attribute."
+  TimelineTransport: xhrTimeline,
 
   getXHRAPI() {
     return window.XMLHttpRequest


### PR DESCRIPTION
## What does this PR do?

Uses the XHR transport for stats requests from the "web" runtime, replacing JSONP. The JSONP transport unnecessarily sends cookies, which results in ugly warnings. The XHR transport does not.

This should fix https://github.com/pusher/pusher-js/issues/392

Open question: were we using JSONP for other reasons?

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
