### PR TITLE
fix #427: custom authorizer callback handles string value

### DIFF
--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -105,7 +105,7 @@ export default class Channel extends EventsDispatcher {
         Logger.error(data);
         this.emit('pusher:subscription_error', data);
       } else {
-        data = data as AuthData;
+        data = typeof data === 'string' ? { auth: data } : (data as AuthData);
         this.pusher.send_event('pusher:subscribe', {
           auth: data.auth,
           channel_data: data.channel_data,


### PR DESCRIPTION
## What does this PR do?

fixes #427 

The callback passed to custom authorizer functions has not
handled string values yet. The provided authorization
data was just castet to an AuthData object.

Now, the string value should be handled correctly.

## Checklist

- [x] All new functionality has tests.
- [OK] All tests are passing.
- [ n.a.] New or changed API methods have been documented.
- [OK ] `npm run format` has been run
