### PR TITLE
Expose type declarations to package consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Pusher Channels JavaScript library for browsers, React Native, NodeJS and web workers",
   "main": "dist/node/pusher.js",
   "browser": "dist/web/pusher.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --config .prettierrc --write 'src/**/*.ts' 'webpack/**/*.js'",


### PR DESCRIPTION
## What does this PR do?

Type declaration files are now shipped in the package. But the package.json was not declaring them, and so they were not taken into account.
