### PR TITLE
Basic encryption support for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,9 @@ const channel = pusher.subscribe('private-my-channel');
 
 Like private channels, encrypted channels have their own namespace, 'private-encrypted-'. For more information about encrypted channels, please see the [docs](https://pusher.com/docs/client_api_guide/client_encrypted_channels).
 
-Please note that encrypted channels are only officially supported for our 'web' and 'node' clients for now. We know for sure this won't work in React Native builds since the React Native runtime does not include the required crypto functionality we depend on. Please let us know if you need this functionality in our web-worker or React Native builds!
+Please note that encrypted channels are only officially supported for our 'web' and 'node' clients for now. 
+React Native supported only without using randomBytes, since the React Native runtime does not include the required crypto functionality we depend on. 
+Please let us know if you need additional functionality in our web-worker or React Native builds!
 
 ```js
 const channel = pusher.subscribe('private-encrypted-my-channel');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,18 @@
       "integrity": "sha512-E5AQ2D0qR/uQ7heGSCT8LdDIqGM2Gle7bH8WoQO4zExn4pqz9ZJT1UyysjLnpJthejOU//owbydWqIZE+JNpSA==",
       "dev": true
     },
+    "@stablelib/base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.0.tgz",
+      "integrity": "sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ==",
+      "dev": true
+    },
+    "@stablelib/utf8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
+      "integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2667,7 +2679,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2688,12 +2701,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2708,17 +2723,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2835,7 +2853,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2847,6 +2866,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2861,6 +2881,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2868,12 +2889,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2892,6 +2915,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2972,7 +2996,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2984,6 +3009,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3069,7 +3095,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3105,6 +3132,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3124,6 +3152,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3167,12 +3196,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3866,6 +3897,24 @@
       "requires": {
         "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
+      }
+    },
+    "imports-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.8.0.tgz",
+      "integrity": "sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
   "homepage": "https://github.com/pusher/pusher-js",
   "devDependencies": {
     "@react-native-community/netinfo": "^4.1.1",
+    "@stablelib/base64": "^1.0.0",
+    "@stablelib/utf8": "^1.0.0",
     "faye-websocket": "^0.9.4",
     "fetch-mock": "git+https://git@github.com/jpatel531/fetch-mock.git",
+    "imports-loader": "^0.8.0",
     "isomorphic-fetch": "^2.2.1",
     "jasmine-node": "^3.0.0",
     "jasmine-spec-reporter": "^1.2.0",

--- a/src/core/channels/channels.ts
+++ b/src/core/channels/channels.ts
@@ -63,12 +63,6 @@ export default class Channels {
 
 function createChannel(name: string, pusher: Pusher): Channel {
   if (name.indexOf('private-encrypted-') === 0) {
-    // We don't currently support e2e on React Native due to missing functionality.
-    // This prevents any weirdness by just returning a private channel instead.
-    if (RUNTIME === 'react-native') {
-      let errorMsg = `Encrypted channels are not yet supported when using React Native builds.`;
-      throw new Errors.UnsupportedFeature(errorMsg);
-    }
     return Factory.createEncryptedChannel(name, pusher);
   } else if (name.indexOf('private-') === 0) {
     return Factory.createPrivateChannel(name, pusher);

--- a/src/runtimes/react-native/tweetnacl-dummy.ts
+++ b/src/runtimes/react-native/tweetnacl-dummy.ts
@@ -1,4 +1,0 @@
-export default {
-  secretbox: {},
-  randomBytes: {}
-};

--- a/src/runtimes/react-native/tweetnacl-util-dummy.ts
+++ b/src/runtimes/react-native/tweetnacl-util-dummy.ts
@@ -1,6 +1,0 @@
-export default {
-  encodeUTF8: {},
-  decodeUTF8: {},
-  encodeBase64: {},
-  decodeBase64: {}
-};

--- a/src/runtimes/react-native/tweetnacl-util-rn.ts
+++ b/src/runtimes/react-native/tweetnacl-util-rn.ts
@@ -1,0 +1,7 @@
+import * as base64 from '@stablelib/base64';
+import * as utf8 from '@stablelib/utf8';
+
+export const encodeUTF8 = utf8.decode;
+export const decodeUTF8 = utf8.encode;
+export const encodeBase64 = base64.encode;
+export const decodeBase64 = base64.decode;

--- a/types/src/runtimes/react-native/tweetnacl-util-rn.d.ts
+++ b/types/src/runtimes/react-native/tweetnacl-util-rn.d.ts
@@ -1,0 +1,6 @@
+import * as base64 from '@stablelib/base64';
+import * as utf8 from '@stablelib/utf8';
+export declare const encodeUTF8: typeof utf8.decode;
+export declare const decodeUTF8: typeof utf8.encode;
+export declare const encodeBase64: typeof base64.encode;
+export declare const decodeBase64: typeof base64.decode;

--- a/webpack/config.react-native.js
+++ b/webpack/config.react-native.js
@@ -18,22 +18,28 @@ module.exports = objectAssign({}, configShared, {
     // our Reachability implementation needs to reference @react-native-community/netinfo.
     '@react-native-community/netinfo': '@react-native-community/netinfo'
   },
+  // React Native implementation not using randomBytes generation of tweenacl and therefore require("crypto"),
+  // we're decieving the tweetnacl, that we're not Node platform and not including require("crypto") into the pusher
+  // Partly from tweetnacl wiki https://github.com/dchest/tweetnacl-js/wiki/Using-with-Webpack
+  module: {
+    rules: [
+      {
+        test: /[\\\/]tweetnacl[\\\/]/,
+        use: 'imports-loader?require\=\>undefined'
+     }
+    ],
+    noParse: [
+      /[\\\/]tweetnacl[\\\/]/,
+    ],
+  },
   resolve: {
     modules: ['src/runtimes/react-native'],
-    // at the moment, react-native doesn't contain the requisite crypto APIs to
-    // use tweetnacl/tweetnacl-utils.
-    //
-    // As a result encrypted channels cannot be supported in react native at
-    // this time. In order for the build to work, we need to replace the
-    // tweetnacl-utils with 'mocks'
     alias: {
-      tweetnacl: path.resolve(
-        __dirname,
-        '../src/runtimes/react-native/tweetnacl-dummy.ts'
-      ),
+      // Using stable libs instead of tweetnacl-utils like the owner is suggesting
+      // https://github.com/dchest/tweetnacl-util-js/blob/master/README.md#notice
       'tweetnacl-util': path.resolve(
         __dirname,
-        '../src/runtimes/react-native/tweetnacl-util-dummy.ts'
+        '../src/runtimes/react-native/tweetnacl-util-rn.ts'
       )
     }
   },


### PR DESCRIPTION
## What does this PR do?

Hello! 👋 
For our React Native project we need to use the encrypted-channels feature, but it's not currently supported. So we decided to give it a push :)

My first implementation was more complex with changes in tweetnacl for random generating as well, but as I understand, pusher not using any methods of tweetnacl, that use randomBytes, so **main idea** ->  just drop the init of tweetnacl randomBytes completely on the webpack level.

Other changes:
- tweetnacl-util using stable packages for encoding/decoding as owner [suggests](https://github.com/dchest/tweetnacl-util-js/blob/master/README.md#notice)
- react native error dropped for the encryption channels (maybe we should put there some warning?)
- docs updated

Please, look at the main idea, if it's viable, I'll create react-native test suite as well.

## Checklist

- [ ] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [ ] `npm run format` has been run
