### PR TITLE
refactor config

### DIFF
--- a/spec/javascripts/integration/core/cluster_config_spec.js
+++ b/spec/javascripts/integration/core/cluster_config_spec.js
@@ -101,20 +101,20 @@ module.exports = function(testConfigs) {
     }
 
     var _VERSION;
-    var _channel_auth_transport;
-    var _channel_auth_endpoint;
+    var _authTransport;
+    var _authEndpoint;
     var _Dependencies;
 
     it("should prepare the global config", function() {
       // TODO fix how versions work in unit tests
       _VERSION = Defaults.VERSION;
-      _channel_auth_transport = Defaults.channel_auth_transport;
-      _channel_auth_endpoint = Defaults.channel_auth_endpoint;
+      _authTransport = Defaults.authTransport;
+      _authEndpoint = Defaults.authEndpoint;
       _Dependencies = Dependencies;
 
       Defaults.VERSION = "8.8.8";
-      Defaults.channel_auth_transport = "";
-      Defaults.channel_auth_endpoint = "";
+      Defaults.authTransport = "";
+      Defaults.authEndpoint = "";
 
       if (TestEnv === "web") {
         Dependencies = new DependencyLoader({

--- a/spec/javascripts/integration/core/pusher_spec/index.js
+++ b/spec/javascripts/integration/core/pusher_spec/index.js
@@ -26,20 +26,20 @@ module.exports = function(testConfigs) {
     // significant delays and triggers security mechanisms in some browsers.
 
     var _VERSION;
-    var _channel_auth_transport;
-    var _channel_auth_endpoint;
+    var _authTransport;
+    var _authEndpoint;
     var _Dependencies;
 
     it("should prepare the global config", function() {
       // TODO fix how versions work in unit tests
       _VERSION = Defaults.VERSION;
-      _channel_auth_transport = Defaults.channel_auth_transport;
-      _channel_auth_endpoint = Defaults.channel_auth_endpoint;
+      _authTransport = Defaults.authTransport;
+      _authEndpoint = Defaults.authEndpoint;
       _Dependencies = Dependencies;
 
       Defaults.VERSION = "8.8.8";
-      Defaults.channel_auth_transport = (TestEnv === 'web') ? 'jsonp' : 'ajax';
-      Defaults.channel_auth_endpoint = Integration.API_URL + "/auth";
+      Defaults.authTransport = (TestEnv === 'web') ? 'jsonp' : 'ajax';
+      Defaults.authEndpoint = Integration.API_URL + "/auth";
 
       if (TestEnv === "web") {
         Dependencies = new DependencyLoader({
@@ -59,8 +59,8 @@ module.exports = function(testConfigs) {
 
     it("should restore the global config", function() {
       Dependencies = _Dependencies;
-      Defaults.channel_auth_endpoint = _channel_auth_endpoint;
-      Defaults.channel_auth_transport = _channel_auth_transport;
+      Defaults.authEndpoint = _authEndpoint;
+      Defaults.authTransport = _authTransport;
       Defaults.VERSION = _VERSION;
     });
   });

--- a/spec/javascripts/integration/core/timeout_configuration_spec.js
+++ b/spec/javascripts/integration/core/timeout_configuration_spec.js
@@ -49,7 +49,7 @@ module.exports = function() {
       pusher.connect();
       pusher.connection.bind("unavailable", onUnavailable);
 
-      jasmine.Clock.tick(Defaults.unavailable_timeout - 1);
+      jasmine.Clock.tick(Defaults.unavailableTimeout - 1);
       expect(onUnavailable).not.toHaveBeenCalled();
       jasmine.Clock.tick(1);
       expect(onUnavailable).toHaveBeenCalled();
@@ -58,7 +58,7 @@ module.exports = function() {
     it("should transition to unavailable after timeout passed as an option", function() {
       var onUnavailable = jasmine.createSpy("onUnavailable");
 
-      pusher = new Pusher("foobar", { unavailable_timeout: 2345 });
+      pusher = new Pusher("foobar", { unavailableTimeout: 2345 });
       pusher.connect();
       pusher.connection.bind("unavailable", onUnavailable);
 
@@ -94,7 +94,7 @@ module.exports = function() {
       jasmine.Clock.tick(1);
       expect(firstTransport.send).toHaveBeenCalled();
 
-      jasmine.Clock.tick(Defaults.pong_timeout - 1);
+      jasmine.Clock.tick(Defaults.pongTimeout - 1);
       expect(firstTransport.close).not.toHaveBeenCalled();
       jasmine.Clock.tick(1);
       expect(firstTransport.close).toHaveBeenCalled();
@@ -102,8 +102,8 @@ module.exports = function() {
 
     it("should obey the activity timeout from the handshake if it's lower than one specified in options", function() {
       pusher = new Pusher("foobar", {
-        activity_timeout: 16000,
-        pong_timeout: 2222
+        activityTimeout: 16000,
+        pongTimeout: 2222
       });
       pusher.connect();
 
@@ -132,8 +132,8 @@ module.exports = function() {
 
     it("should obey the activity timeout specified in options if it's lower than one from the handshake", function() {
       pusher = new Pusher("foobar", {
-        activity_timeout: 15555,
-        pong_timeout: 2222
+        activityTimeout: 15555,
+        pongTimeout: 2222
       });
       pusher.connect();
 
@@ -162,7 +162,7 @@ module.exports = function() {
 
     it("should obey the pong timeout passed in options", function() {
       pusher = new Pusher("foobar", {
-        pong_timeout: 2222
+        pongTimeout: 2222
       });
       pusher.connect();
 

--- a/spec/javascripts/unit/core/config_spec.js
+++ b/spec/javascripts/unit/core/config_spec.js
@@ -1,0 +1,109 @@
+var TestEnv = require('testenv');
+var Config = require('core/config');
+var Defaults = require('core/defaults').default;
+var Runtime = require('runtime').default;
+
+describe('Config', function() {
+  beforeEach(function() {
+    if (TestEnv === 'web') {
+      spyOn(Runtime, 'getDocument').andReturn({
+        location: {
+          protocol: 'http:'
+        }
+      });
+    }
+  });
+
+  it('should populate defaults', function() {
+    let config = Config.getConfig({});
+    for (let key in getStaticDefaultKeys()) {
+      expect(config[key]).toEqual(Defaults[key])
+    }
+  });
+
+  it('should disable stats by default', function() {
+    let config = Config.getConfig({});
+    expect(config.enableStats).toEqual(false)
+  });
+
+  it('should allow enabling of stats', function() {
+    let config = Config.getConfig({enableStats: true});
+    expect(config.enableStats).toEqual(true)
+  });
+
+  it('should honour deprecated disableStats option', function() {
+    let config = Config.getConfig({disableStats: true});
+    expect(config.enableStats).toEqual(false)
+
+    config = Config.getConfig({disableStats: false});
+    expect(config.enableStats).toEqual(true)
+  });
+
+
+  it('should override config with supplied options', function() {
+    let opts = {
+      pongTimeout: 123,
+      activityTimeout: 345,
+      ignoreNullOrigin: true,
+      authorizer: () => {},
+      authTransport: 'some-auth-transport',
+      authEndpoint: '/pusher/spec/auth',
+      auth: {
+        params: { spec: 'param' },
+        headers: { spec: 'header' }
+      },
+      wsHost: 'ws-spec.pusher.com',
+      wsPort: 2020,
+      wssPort: 2021,
+      httpHost: 'socksjs-spec.pusher.com',
+      httpPort: 1020,
+      httpsPort: 1021,
+      enableStats: true
+    };
+    let config = Config.getConfig(opts);
+    expect(config).toEqual(jasmine.objectContaining(opts));
+    for (let opt in opts) {
+      expect(config[opt]).toEqual(opts[opt]);
+    }
+  });
+
+  describe('TLS', function() {
+    it('should use TLS if forceTLS set', function() {
+      let config = Config.getConfig({ forceTLS: true });
+      expect(config.useTLS).toEqual(true);
+    });
+    // deprecated
+    it('should use TLS if encrypted set', function() {
+      let config = Config.getConfig({ encrypted: true });
+      expect(config.useTLS).toEqual(true);
+    });
+    if (TestEnv === 'web') {
+      it('should use TLS when using https', function() {
+        Runtime.getDocument.andReturn({
+          location: {
+            protocol: 'https:'
+          }
+        });
+        let config = Config.getConfig({});
+        expect(config.useTLS).toEqual(true);
+      });
+    }
+  });
+});
+function getStaticDefaultKeys() {
+  return [
+    'activityTimeout',
+    'authEndpoint',
+    'authTransport',
+    'cluster',
+    'httpPath',
+    'httpPort',
+    'httpsPort',
+    'pongTimeout',
+    'statsHost',
+    'unavailableTimeout',
+    'wsPath',
+    'wsPort',
+    'wssPort'
+  ]
+}

--- a/spec/javascripts/unit/core/connection/connection_manager_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_manager_spec.js
@@ -21,7 +21,8 @@ describe("ConnectionManager", function() {
       timeline: timeline,
       activityTimeout: 3456,
       pongTimeout: 2345,
-      unavailableTimeout: 1234
+      unavailableTimeout: 1234,
+      useTLS: false,
     };
     manager = new ConnectionManager("foo", managerOptions);
   });
@@ -47,7 +48,7 @@ describe("ConnectionManager", function() {
         activityTimeout: 3456,
         pongTimeout: 2345,
         unavailableTimeout: 1234
-      });
+      }, {});
       expect(getStrategy).toHaveBeenCalled();
     });
 
@@ -63,7 +64,8 @@ describe("ConnectionManager", function() {
 
     it("should return true if the manager has been created with useTLS=true", function() {
       var manager = new ConnectionManager(
-        "foo", Collections.extend(managerOptions, { useTLS: true })
+        "foo",
+        Object.assign({}, managerOptions, { useTLS: true })
       );
       expect(manager.isUsingTLS()).toEqual(true);
     });

--- a/spec/javascripts/unit/core/defaults_spec.js
+++ b/spec/javascripts/unit/core/defaults_spec.js
@@ -1,7 +1,7 @@
 var WSTransport = require('runtime').default.Transports.ws;
 var StrategyBuilder = require('core/strategies/strategy_builder');
 var Runtime = require('runtime').default;
-var DefaultConfig = require('core/config');
+var Config = require('core/config');
 
 describe("Default", function() {
   describe("strategy", function() {
@@ -10,7 +10,11 @@ describe("Default", function() {
         if (ws) {
           spyOn(WSTransport, "isSupported").andReturn(true);
         }
-        var strategy = Runtime.getDefaultStrategy(DefaultConfig.getGlobalConfig(), StrategyBuilder.defineTransport);
+        var strategy = Runtime.getDefaultStrategy(
+          Config.getConfig({}),
+          {},
+          StrategyBuilder.defineTransport,
+        );
         expect(strategy.isSupported()).toBe(true);
       });
     }

--- a/spec/javascripts/unit/core/transports/hosts_and_ports_spec.js
+++ b/spec/javascripts/unit/core/transports/hosts_and_ports_spec.js
@@ -46,21 +46,21 @@ describe("Host/Port Configuration", function() {
       }
     });
 
-    it("should connect to ws://ws.pusherapp.com:80 by default", function() {
+    it("should connect to ws://ws-mt1.pusher.com:80 by default", function() {
       pusher = new Pusher("foobar");
       pusher.connect();
 
       expect(Runtime.createWebSocket).toHaveBeenCalledWith(
-        "ws://ws.pusherapp.com:80/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
+        "ws://ws-mt1.pusher.com:80/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
       );
     });
 
-    it("should connect to wss://ws.pusherapp.com:443 by default when forcing TLS", function() {
+    it("should connect to wss://ws-mt1.pusher.com:443 by default when forcing TLS", function() {
       pusher = new Pusher("foobar", { forceTLS: true });
       pusher.connect();
 
       expect(Runtime.createWebSocket).toHaveBeenCalledWith(
-        "wss://ws.pusherapp.com:443/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
+        "wss://ws-mt1.pusher.com:443/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
       );
     });
 

--- a/spec/javascripts/unit/isomorphic/transports/hosts_and_ports_spec.js
+++ b/spec/javascripts/unit/isomorphic/transports/hosts_and_ports_spec.js
@@ -41,21 +41,21 @@ describe("Host/Port Configuration", function() {
       spyOn(Transports.xhr_polling, "isSupported").andReturn(false);
     });
 
-    it("should connect to ws://ws.pusherapp.com:80 by default", function() {
+    it("should connect to ws://ws-mt1.pusher.com:80 by default", function() {
       pusher = new Pusher("foobar");
       pusher.connect();
 
       expect(Runtime.createWebSocket).toHaveBeenCalledWith(
-        "ws://ws.pusherapp.com:80/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
+        "ws://ws-mt1.pusher.com:80/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
       );
     });
 
-    it("should connect to wss://ws.pusherapp.com:443 by default when forcing TLS", function() {
+    it("should connect to wss://ws-mt1.pusher.com:443 by default when forcing TLS", function() {
       pusher = new Pusher("foobar", { forceTLS: true });
       pusher.connect();
 
       expect(Runtime.createWebSocket).toHaveBeenCalledWith(
-        "wss://ws.pusherapp.com:443/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
+        "wss://ws-mt1.pusher.com:443/app/foobar?protocol=7&client=js&version="+version+"&flash=false"
       );
     });
 

--- a/src/core/auth/options.ts
+++ b/src/core/auth/options.ts
@@ -1,8 +1,8 @@
 import Channel from '../channels/channel';
 
 export interface AuthOptions {
-  params: any;
-  headers: any;
+  params?: any;
+  headers?: any;
 }
 
 export interface AuthData {
@@ -24,6 +24,6 @@ export interface AuthorizerGenerator {
 
 export interface AuthorizerOptions {
   authTransport: 'ajax' | 'jsonp';
-  auth: AuthOptions;
-  authorizer: AuthorizerGenerator;
+  auth?: AuthOptions;
+  authorizer?: AuthorizerGenerator;
 }

--- a/src/core/auth/pusher_authorizer.ts
+++ b/src/core/auth/pusher_authorizer.ts
@@ -29,7 +29,7 @@ export default class PusherAuthorizer implements Authorizer {
 
     this.type = authTransport;
     this.options = options;
-    this.authOptions = (options || <any>{}).auth || {};
+    this.authOptions = options.auth || {};
   }
 
   composeQuery(socketId: string): string {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,28 +1,127 @@
+import { Options } from './options';
 import Defaults from './defaults';
+import { AuthOptions, AuthorizerGenerator } from './auth/options';
+import Runtime from 'runtime';
 
-export var getGlobalConfig = function() {
-  return {
-    wsHost: Defaults.host,
-    wsPort: Defaults.ws_port,
-    wssPort: Defaults.wss_port,
-    wsPath: Defaults.ws_path,
-    httpHost: Defaults.sockjs_host,
-    httpPort: Defaults.sockjs_http_port,
-    httpsPort: Defaults.sockjs_https_port,
-    httpPath: Defaults.sockjs_path,
-    statsHost: Defaults.stats_host,
-    authEndpoint: Defaults.channel_auth_endpoint,
-    authTransport: Defaults.channel_auth_transport,
-    // TODO make this consistent with other options in next major version
-    activity_timeout: Defaults.activity_timeout,
-    pong_timeout: Defaults.pong_timeout,
-    unavailable_timeout: Defaults.unavailable_timeout
-  };
-};
+export type AuthTransport = 'ajax' | 'jsonp';
+export type Transport =
+  | 'ws'
+  | 'wss'
+  | 'xhr_streaming'
+  | 'xhr_polling'
+  | 'sockjs';
 
-export var getClusterConfig = function(clusterName) {
-  return {
-    wsHost: 'ws-' + clusterName + '.pusher.com',
-    httpHost: 'sockjs-' + clusterName + '.pusher.com'
+export interface Config {
+  // these are all 'required' config parameters, it's not necessary for the user
+  // to set them, but they have configured defaults.
+  activityTimeout: number;
+  authEndpoint: string;
+  authTransport: AuthTransport;
+  enableStats: boolean;
+  httpHost: string;
+  httpPath: string;
+  httpPort: number;
+  httpsPort: number;
+  pongTimeout: number;
+  statsHost: string;
+  unavailableTimeout: number;
+  useTLS: boolean;
+  wsHost: string;
+  wsPath: string;
+  wsPort: number;
+  wssPort: number;
+
+  // these are all optional parameters or overrrides. The customer can set these
+  // but it's not strictly necessary
+  forceTLS?: boolean;
+  auth?: AuthOptions;
+  authorizer?: AuthorizerGenerator;
+  cluster?: string;
+  disabledTransports?: Transport[];
+  enabledTransports?: Transport[];
+  ignoreNullOrigin?: boolean;
+  timelineParams?: any;
+}
+
+export function getConfig(opts: Options): Config {
+  let config: Config = {
+    activityTimeout: opts.activityTimeout || Defaults.activityTimeout,
+    authEndpoint: opts.authEndpoint || Defaults.authEndpoint,
+    authTransport: opts.authTransport || Defaults.authTransport,
+    cluster: opts.cluster || Defaults.cluster,
+    httpPath: opts.httpPath || Defaults.httpPath,
+    httpPort: opts.httpPort || Defaults.httpPort,
+    httpsPort: opts.httpsPort || Defaults.httpsPort,
+    pongTimeout: opts.pongTimeout || Defaults.pongTimeout,
+    statsHost: opts.statsHost || Defaults.stats_host,
+    unavailableTimeout: opts.unavailableTimeout || Defaults.unavailableTimeout,
+    wsPath: opts.wsPath || Defaults.wsPath,
+    wsPort: opts.wsPort || Defaults.wsPort,
+    wssPort: opts.wssPort || Defaults.wssPort,
+
+    enableStats: getEnableStatsConfig(opts),
+    httpHost: getHttpHost(opts),
+    useTLS: shouldUseTLS(opts),
+    wsHost: getWebsocketHost(opts)
   };
-};
+
+  if ('auth' in opts) config.auth = opts.auth;
+  if ('authorizer' in opts) config.authorizer = opts.authorizer;
+  if ('disabledTransports' in opts)
+    config.disabledTransports = opts.disabledTransports;
+  if ('enabledTransports' in opts)
+    config.enabledTransports = opts.enabledTransports;
+  if ('ignoreNullOrigin' in opts)
+    config.ignoreNullOrigin = opts.ignoreNullOrigin;
+  if ('timelineParams' in opts) config.timelineParams = opts.timelineParams;
+
+  return config;
+}
+
+function getHttpHost(opts: Options): string {
+  if (opts.httpHost) {
+    return opts.httpHost;
+  }
+  if (opts.cluster) {
+    return `sockjs-${opts.cluster}.pusher.com`;
+  }
+  return Defaults.httpHost;
+}
+
+function getWebsocketHost(opts: Options): string {
+  if (opts.wsHost) {
+    return opts.wsHost;
+  }
+  if (opts.cluster) {
+    return getWebsocketHostFromCluster(opts.cluster);
+  }
+  return getWebsocketHostFromCluster(Defaults.cluster);
+}
+
+function getWebsocketHostFromCluster(cluster: string): string {
+  return `ws-${cluster}.pusher.com`;
+}
+
+function shouldUseTLS(opts: Options): boolean {
+  if (Runtime.getProtocol() === 'https:') {
+    return true;
+  } else if (opts.forceTLS === true) {
+    return true;
+  } else {
+    // `encrypted` deprecated in favor of `forceTLS`
+    return Boolean(opts.encrypted);
+  }
+}
+
+// if enableStats is set take the value
+// if disableStats is set take the inverse
+// otherwise default to false
+function getEnableStatsConfig(opts: Options): boolean {
+  if ('enableStats' in opts) {
+    return opts.enableStats;
+  }
+  if ('disableStats' in opts) {
+    return !opts.disableStats;
+  }
+  return false;
+}

--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -1,5 +1,6 @@
 import { default as EventsDispatcher } from '../events/dispatcher';
 import { OneOffTimer as Timer } from '../utils/timers';
+import { Config } from '../config';
 import Logger from '../logger';
 import HandshakePayload from './handshake/handshake_payload';
 import Connection from './connection';
@@ -9,6 +10,7 @@ import * as Collections from '../utils/collections';
 import Timeline from '../timeline/timeline';
 import ConnectionManagerOptions from './connection_manager_options';
 import Runtime from 'runtime';
+
 import {
   ErrorCallbacks,
   HandshakeCallbacks,
@@ -60,14 +62,15 @@ export default class ConnectionManager extends EventsDispatcher {
   handshakeCallbacks: HandshakeCallbacks;
   connectionCallbacks: ConnectionCallbacks;
 
-  constructor(key: string, options: any) {
+  constructor(key: string, options: ConnectionManagerOptions) {
     super();
-    this.key = key;
-    this.options = options || {};
     this.state = 'initialized';
     this.connection = null;
-    this.usingTLS = !!options.useTLS;
+
+    this.key = key;
+    this.options = options;
     this.timeline = this.options.timeline;
+    this.usingTLS = this.options.useTLS;
 
     this.errorCallbacks = this.buildErrorCallbacks();
     this.connectionCallbacks = this.buildConnectionCallbacks(

--- a/src/core/connection/connection_manager_options.ts
+++ b/src/core/connection/connection_manager_options.ts
@@ -8,6 +8,7 @@ interface ConnectionManagerOptions {
   unavailableTimeout: number;
   pongTimeout: number;
   activityTimeout: number;
+  useTLS: boolean;
 }
 
 export default ConnectionManagerOptions;

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -1,20 +1,22 @@
+import { AuthTransport } from './config';
+
 export interface DefaultConfig {
   VERSION: string;
   PROTOCOL: number;
-  host: string;
-  ws_port: number;
-  wss_port: number;
-  ws_path: string;
-  sockjs_host: string;
-  sockjs_http_port: number;
-  sockjs_https_port: number;
-  sockjs_path: string;
+  wsPort: number;
+  wssPort: number;
+  wsPath: string;
+  httpHost: string;
+  httpPort: number;
+  httpsPort: number;
+  httpPath: string;
   stats_host: string;
-  channel_auth_endpoint: string;
-  channel_auth_transport: string;
-  activity_timeout: number;
-  pong_timeout: number;
-  unavailable_timeout: number;
+  authEndpoint: string;
+  authTransport: AuthTransport;
+  activityTimeout: number;
+  pongTimeout: number;
+  unavailableTimeout: number;
+  cluster: string;
 
   cdn_http?: string;
   cdn_https?: string;
@@ -25,24 +27,23 @@ var Defaults: DefaultConfig = {
   VERSION: VERSION,
   PROTOCOL: 7,
 
-  // DEPRECATED: WS connection parameters
-  host: 'ws.pusherapp.com',
-  ws_port: 80,
-  wss_port: 443,
-  ws_path: '',
+  wsPort: 80,
+  wssPort: 443,
+  wsPath: '',
   // DEPRECATED: SockJS fallback parameters
-  sockjs_host: 'sockjs.pusher.com',
-  sockjs_http_port: 80,
-  sockjs_https_port: 443,
-  sockjs_path: '/pusher',
+  httpHost: 'sockjs.pusher.com',
+  httpPort: 80,
+  httpsPort: 443,
+  httpPath: '/pusher',
   // DEPRECATED: Stats
   stats_host: 'stats.pusher.com',
   // DEPRECATED: Other settings
-  channel_auth_endpoint: '/pusher/auth',
-  channel_auth_transport: 'ajax',
-  activity_timeout: 120000,
-  pong_timeout: 30000,
-  unavailable_timeout: 10000,
+  authEndpoint: '/pusher/auth',
+  authTransport: 'ajax',
+  activityTimeout: 120000,
+  pongTimeout: 30000,
+  unavailableTimeout: 10000,
+  cluster: 'mt1',
 
   // CDN configuration
   cdn_http: CDN_HTTP,

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,48 +1,31 @@
 import ConnectionManager from './connection/connection_manager';
 import { AuthOptions, AuthorizerGenerator } from './auth/options';
-
-export interface PusherOptions {
-  cluster: string;
-  disableStats: boolean;
-  enableStats: boolean;
-  statsHost: string;
-  activity_timeout: number;
-  pong_timeout: number;
-  unavailable_timeout: number;
-  forceTLS: boolean;
-  encrypted: boolean;
-  timelineParams: any;
-  authTransport: 'ajax' | 'jsonp';
-  auth: AuthOptions;
-  authorizer: AuthorizerGenerator;
-}
-
-type Transport = 'ws' | 'wss' | 'xhr_streaming' | 'xhr_polling' | 'sockjs';
-type AuthTransport = 'ajax' | 'jsonp';
+import { AuthTransport, Transport } from './config';
 
 export interface Options {
   activityTimeout?: number;
-  enableStats?: boolean;
-  disableStats?: boolean; // deprecated
-  authEndpoint?: string;
   auth?: AuthOptions;
+  authEndpoint?: string;
   authTransport?: AuthTransport;
   authorizer?: AuthorizerGenerator;
+  cluster?: string;
+  enableStats?: boolean;
+  disableStats?: boolean;
   disabledTransports?: Transport[];
   enabledTransports?: Transport[];
   encrypted?: boolean;
   forceTLS?: boolean;
+  httpHost?: string;
+  httpPath?: string;
+  httpPort?: number;
+  httpsPort?: number;
   ignoreNullOrigin?: boolean;
   pongTimeout?: number;
   statsHost?: string;
   timelineParams?: any;
-  unavailable_timeout?: number;
-  cluster?: string;
+  unavailableTimeout?: number;
   wsHost?: string;
-  httpHost?: string;
   wsPath?: string;
   wsPort?: number;
   wssPort?: number;
-  httpPort?: number;
-  httpsPort?: number;
 }

--- a/src/core/strategies/strategy_builder.ts
+++ b/src/core/strategies/strategy_builder.ts
@@ -4,16 +4,18 @@ import TransportManager from '../transports/transport_manager';
 import * as Errors from '../errors';
 import Strategy from './strategy';
 import TransportStrategy from './transport_strategy';
+import StrategyOptions from '../strategies/strategy_options';
+import { Config } from '../config';
 import Runtime from 'runtime';
 
 const { Transports } = Runtime;
 
 export var defineTransport = function(
-  config: any,
+  config: Config,
   name: string,
   type: string,
   priority: number,
-  options,
+  options: StrategyOptions,
   manager?: TransportManager
 ): Strategy {
   var transportClass = Transports[type];
@@ -29,19 +31,16 @@ export var defineTransport = function(
 
   var transport;
   if (enabled) {
+    options = Object.assign(
+      { ignoreNullOrigin: config.ignoreNullOrigin },
+      options
+    );
+
     transport = new TransportStrategy(
       name,
       priority,
       manager ? manager.getAssistant(transportClass) : transportClass,
-      Collections.extend(
-        {
-          key: config.key,
-          useTLS: config.useTLS,
-          timeline: config.timeline,
-          ignoreNullOrigin: config.ignoreNullOrigin
-        },
-        options
-      )
+      options
     );
   } else {
     transport = UnsupportedStrategy;

--- a/src/core/strategies/strategy_options.ts
+++ b/src/core/strategies/strategy_options.ts
@@ -1,13 +1,18 @@
+import Timeline from '../timeline/timeline';
+
 interface StrategyOptions {
-  ttl?: number;
-  timeline?: any;
-  useTLS?: boolean;
-  ignoreNullOrigin?: boolean;
-  loop?: boolean;
   failFast?: boolean;
+  hostNonTLS?: string;
+  hostTLS?: string;
+  httpPath?: string;
+  ignoreNullOrigin?: boolean;
+  key?: string;
+  loop?: boolean;
+  timeline?: Timeline;
   timeout?: number;
   timeoutLimit?: number;
-  key?: string;
+  ttl?: number;
+  useTLS?: boolean;
 }
 
 export default StrategyOptions;

--- a/src/core/strategies/transport_strategy.ts
+++ b/src/core/strategies/transport_strategy.ts
@@ -55,7 +55,6 @@ export default class TransportStrategy implements Strategy {
     }
 
     var connected = false;
-
     var transport = this.transport.createConnection(
       this.name,
       this.priority,

--- a/src/core/transports/transport.ts
+++ b/src/core/transports/transport.ts
@@ -1,6 +1,7 @@
 import Factory from '../utils/factory';
 import TransportHooks from './transport_hooks';
 import TransportConnection from './transport_connection';
+import TransportConnectionOptions from './transport_connection_options';
 
 /** Provides interface for transport connection instantiation.
  *

--- a/src/core/utils/factory.ts
+++ b/src/core/utils/factory.ts
@@ -22,6 +22,7 @@ import ConnectionManagerOptions from '../connection/connection_manager_options';
 import Ajax from '../http/ajax';
 import Channels from '../channels/channels';
 import Pusher from '../pusher';
+import { Config } from '../config';
 
 var Factory = {
   createChannels(): Channels {

--- a/src/runtimes/interface.ts
+++ b/src/runtimes/interface.ts
@@ -10,6 +10,8 @@ import HTTPRequest from '../core/http/http_request';
 import Pusher from '../core/pusher';
 import JSONPRequest from './web/dom/jsonp_request';
 import Strategy from '../core/strategies/strategy';
+import { Config } from '../core/config';
+import StrategyOptions from '../core/strategies/strategy_options';
 
 /*
 This interface is implemented in web/runtime, node/runtime, react-native/runtime
@@ -30,7 +32,11 @@ interface Runtime {
   createXHR(): Ajax;
   createWebSocket(url: string): Socket;
   getNetwork(): Reachability;
-  getDefaultStrategy(config: any, defineTransport: Function): Strategy;
+  getDefaultStrategy(
+    config: Config,
+    options: StrategyOptions,
+    defineTransport: Function
+  ): Strategy;
   Transports: TransportsTable;
   getWebSocketAPI(): new (url: string) => Socket;
   getXHRAPI(): new () => Ajax;


### PR DESCRIPTION
## What does this PR do?

Separate Options from Config.

Previously the configuration of the library was very confusing. Configuration
objects were frequently composed by combining multiple different objects with
`Collections.extend`. Types annotations were absent and it made tracing the
config tricky.

There were also default configuration settings dotted all around the codebase
making it hard to see where parameters were set

This PR tries to improve that by separating the Options (an object of optional
parameters passed into the constructor by the user of the library) from the
Config (the full configuration object used by the library). The Config has
default parameters but can be overridden by Options

- create distinct types for the Config (used by the library) and the
Options (argument passed into the constructor allowing the library user
    to override default Config parameters)

- move the config creation all into the config module
- add a default cluster and set it on the config - this means that if no cluster is supplied, clients connect to `ws-mt1.pusher.com` not `ws-pusherapp.com` as previously
- fix tests that expect pusherapp.com host

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
~- [ ] New or changed API methods have been documented.~ there shouldn't be any
- [x] `npm run format` has been run
