### PR TITLE
pass global config to subclass

### DIFF
--- a/spec/javascripts/unit/core/pusher_with_encryption_spec.js
+++ b/spec/javascripts/unit/core/pusher_with_encryption_spec.js
@@ -1,0 +1,16 @@
+var Pusher = require('core/pusher').default;
+var PusherWithEncryption = require('core/pusher-with-encryption').default;
+
+describe('PusherWithEncryption', function() {
+  it('should pass logToConsole config to parent class', function() {
+    PusherWithEncryption.logToConsole = true;
+    let pusher = new PusherWithEncryption('key');
+    expect(Pusher.logToConsole).toEqual(true);
+  });
+  it('should pass log function to parent class', function() {
+    let logFn =  jasmine.createSpy('logFn');
+    PusherWithEncryption.log = logFn
+    let pusher = new PusherWithEncryption('key');
+    expect(logFn).toHaveBeenCalled();
+  });
+});

--- a/src/core/pusher-with-encryption.ts
+++ b/src/core/pusher-with-encryption.ts
@@ -4,6 +4,9 @@ import * as nacl from 'tweetnacl';
 
 export default class PusherWithEncryption extends Pusher {
   constructor(app_key: string, options?: Options) {
+    Pusher.logToConsole = PusherWithEncryption.logToConsole;
+    Pusher.log = PusherWithEncryption.log;
+
     options = options || {};
     options.nacl = nacl;
     super(app_key, options);


### PR DESCRIPTION
## What does this PR do?

2 parameters can be set by the caller

```
import Pusher from 'pusher-js;
Pusher.logToConsole;
```

etc

We need to pass these properties on to the subclass

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
