### PR TITLE
Add tweetnacl as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7168,8 +7168,7 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "object-assign-deep": "0.0.4",
     "prettier": "^1.19.1",
     "ts-loader": "^6.0.4",
-    "tweetnacl": "^1.0.3",
     "typescript": "^3.4.5",
     "uglify-js": "^2.6.2",
     "webpack": "^4.41.5",
@@ -61,5 +60,7 @@
     "webpack-dev-server": "^3.7.2",
     "xmlhttprequest": "^1.8.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "tweetnacl": "^1.0.3"
+  }
 }


### PR DESCRIPTION
## What does this PR do?

In order for typescript to be able to properly resolve the module in consumer projects, tweetnacl needs to be a dependency of pusher-js

