### PR TITLE
Update where react-native looks for dist

### DIFF
--- a/react-native/index.js
+++ b/react-native/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/react-native/pusher');
+module.exports = require('../dist/react-native/pusher');


### PR DESCRIPTION
## What does this PR do?

Adds a `.` to the require for the `dist` folder from `react-native/index.js`

The `dist` folder is up a level in the `pusher-js` folder and I am currently getting the error:

```
Unable to resolve module `./dist/react-native/pusher` from `../node_modules/pusher-js/react-native/index.js`
```

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
