### PR TITLE
deleted dummy tweetnacl libs for RN

### DIFF
--- a/src/runtimes/react-native/tweetnacl-dummy.ts
+++ b/src/runtimes/react-native/tweetnacl-dummy.ts
@@ -1,4 +1,0 @@
-export default {
-  secretbox: {},
-  randomBytes: {}
-};

--- a/src/runtimes/react-native/tweetnacl-util-dummy.ts
+++ b/src/runtimes/react-native/tweetnacl-util-dummy.ts
@@ -1,6 +1,0 @@
-export default {
-  encodeUTF8: {},
-  decodeUTF8: {},
-  encodeBase64: {},
-  decodeBase64: {}
-};


### PR DESCRIPTION
## What does this PR do?

Deleted dummy files for old encryption channels implementation for React Native
As I see, it's not needed anymore?

Tested by building new react-native build and try it with encryption channels on our app