### PR TITLE
Node wss sni

### DIFF
--- a/dist/node/pusher.js
+++ b/dist/node/pusher.js
@@ -10199,7 +10199,7 @@ var xhr_timeline_xhr = {
 
 
 
-var runtime_getDefaultStrategy = runtime.getDefaultStrategy, runtime_Transports = runtime.Transports, setup = runtime.setup, getProtocol = runtime.getProtocol, isXHRSupported = runtime.isXHRSupported, getLocalStorage = runtime.getLocalStorage, createXHR = runtime.createXHR, createWebSocket = runtime.createWebSocket, addUnloadListener = runtime.addUnloadListener, removeUnloadListener = runtime.removeUnloadListener, transportConnectionInitializer = runtime.transportConnectionInitializer, createSocketRequest = runtime.createSocketRequest, HTTPFactory = runtime.HTTPFactory;
+var runtime_getDefaultStrategy = runtime.getDefaultStrategy, runtime_Transports = runtime.Transports, setup = runtime.setup, getProtocol = runtime.getProtocol, isXHRSupported = runtime.isXHRSupported, getLocalStorage = runtime.getLocalStorage, createXHR = runtime.createXHR, addUnloadListener = runtime.addUnloadListener, removeUnloadListener = runtime.removeUnloadListener, transportConnectionInitializer = runtime.transportConnectionInitializer, createSocketRequest = runtime.createSocketRequest, HTTPFactory = runtime.HTTPFactory;
 var NodeJS = {
     getDefaultStrategy: runtime_getDefaultStrategy,
     Transports: runtime_Transports,
@@ -10209,7 +10209,6 @@ var NodeJS = {
     createSocketRequest: createSocketRequest,
     getLocalStorage: getLocalStorage,
     createXHR: createXHR,
-    createWebSocket: createWebSocket,
     addUnloadListener: addUnloadListener,
     removeUnloadListener: removeUnloadListener,
     transportConnectionInitializer: transportConnectionInitializer,
@@ -10220,6 +10219,14 @@ var NodeJS = {
     },
     getWebSocketAPI: function () {
         return websocket["Client"];
+    },
+    createWebSocket: function (url) {
+        var Constructor = this.getWebSocketAPI();
+        var socketURL = new URL(url);
+        if (socketURL.protocol === 'wss:') {
+            return new Constructor(url, null, { tls: { servername: socketURL.hostname } });
+        }
+        return new Constructor(url);
     },
     getXHRAPI: function () {
         return XMLHttpRequest["XMLHttpRequest"];

--- a/src/runtimes/node/runtime.ts
+++ b/src/runtimes/node/runtime.ts
@@ -54,7 +54,9 @@ const NodeJS: Runtime = {
     var socketURL = new URL(url);
     // Set servername to enable SNI for wss connections.
     if (socketURL.protocol === 'wss:') {
-      return new Constructor(url, null, {tls: {servername: socketURL.hostname}});
+      return new Constructor(url, null, {
+        tls: { servername: socketURL.hostname }
+      });
     }
     return new Constructor(url);
   },

--- a/src/runtimes/node/runtime.ts
+++ b/src/runtimes/node/runtime.ts
@@ -18,7 +18,6 @@ const {
   isXHRSupported,
   getLocalStorage,
   createXHR,
-  createWebSocket,
   addUnloadListener,
   removeUnloadListener,
   transportConnectionInitializer,
@@ -35,7 +34,6 @@ const NodeJS: Runtime = {
   createSocketRequest,
   getLocalStorage,
   createXHR,
-  createWebSocket,
   addUnloadListener,
   removeUnloadListener,
   transportConnectionInitializer,
@@ -49,6 +47,16 @@ const NodeJS: Runtime = {
 
   getWebSocketAPI() {
     return WebSocket;
+  },
+
+  createWebSocket(url: string) {
+    var Constructor = this.getWebSocketAPI();
+    var socketURL = new URL(url);
+    // Set servername to enable SNI for wss connections.
+    if (socketURL.protocol === 'wss:') {
+      return new Constructor(url, null, {tls: {servername: socketURL.hostname}});
+    }
+    return new Constructor(url);
   },
 
   getXHRAPI() {


### PR DESCRIPTION
## What does this PR do?

The websocket interface of the nodejs runtime is changed, such that it automatically sets the servername property when creating the connection. This property in turn enables SNI during the connection setup and fixes issue where multiple domains are hosted by on the same IP.

## Checklist

- [x] `npm run format` has been run
