### PR TITLE
Don't catch and discard errors thrown by handlers

### DIFF
--- a/src/core/channels/encrypted_channel.ts
+++ b/src/core/channels/encrypted_channel.ts
@@ -119,23 +119,22 @@ export default class EncryptedChannel extends PrivateChannel {
           );
           return;
         }
-        this.emitJSON(event, encodeUTF8(bytes));
+        this.emit(event, this.getDataToEmit(bytes));
         return;
       });
       return;
     }
-
-    this.emitJSON(event, encodeUTF8(bytes));
+    this.emit(event, this.getDataToEmit(bytes));
   }
 
-  emitJSON(eventName: string, data?: any): Dispatcher {
-    let parsedData;
+  // Try and parse the decrypted bytes as JSON. If we can't parse it, just
+  // return the utf-8 string
+  getDataToEmit(bytes: Uint8Array): string {
+    let raw = encodeUTF8(bytes);
     try {
-      parsedData = JSON.parse(data);
+      return JSON.parse(raw);
     } catch {
-      parsedData = data;
+      return raw;
     }
-    this.emit(eventName, parsedData);
-    return this;
   }
 }

--- a/src/core/channels/encrypted_channel.ts
+++ b/src/core/channels/encrypted_channel.ts
@@ -129,11 +129,13 @@ export default class EncryptedChannel extends PrivateChannel {
   }
 
   emitJSON(eventName: string, data?: any): Dispatcher {
+    let parsedData;
     try {
-      this.emit(eventName, JSON.parse(data));
-    } catch (e) {
-      this.emit(eventName, data);
+      parsedData = JSON.parse(data);
+    } catch {
+      parsedData = data;
     }
+    this.emit(eventName, parsedData);
     return this;
   }
 }


### PR DESCRIPTION
## What does this PR do?
As per https://github.com/pusher/pusher-js/issues/437.
If the handler throws an error, we catch it and discard it. We shouldn't be doing anything with the caller's handlers.

## Checklist

- [x] All new functionality has tests.
- [ ] All tests are passing.
- [x] New or changed API methods have been documented.
- [ ] `npm run format` has been run
