### PR TITLE
don't wrap errors from transport

### DIFF
--- a/spec/javascripts/unit/core/connection/connection_manager_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_manager_spec.js
@@ -425,7 +425,10 @@ describe("ConnectionManager", function() {
         var onError = jasmine.createSpy("onError");
         manager.bind("error", onError);
 
-        connection.emit("error", { boom: "boom" });
+        connection.emit("error", {
+          type: "WebSocketError",
+          error: { boom: "boom" }
+        });
 
         expect(onError).toHaveBeenCalledWith({
           type: "WebSocketError",

--- a/spec/javascripts/unit/core/connection/connection_spec.js
+++ b/spec/javascripts/unit/core/connection/connection_spec.js
@@ -272,7 +272,10 @@ describe("Connection", function() {
       var onError = jasmine.createSpy("onError");
       connection.bind("error", onError);
 
-      transport.emit("error", "wut");
+      transport.emit("error", {
+        type: "WebSocketError",
+        error: "wut"
+      });
       expect(onError).toHaveBeenCalledWith({
         type: "WebSocketError",
         error: "wut"

--- a/src/core/connection/connection.ts
+++ b/src/core/connection/connection.ts
@@ -122,7 +122,7 @@ export default class Connection extends EventsDispatcher implements Socket {
         this.emit('activity');
       },
       error: error => {
-        this.emit('error', { type: 'WebSocketError', error: error });
+        this.emit('error', error);
       },
       closed: closeEvent => {
         unbindListeners();

--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -269,7 +269,7 @@ export default class ConnectionManager extends EventsDispatcher {
       },
       error: error => {
         // just emit error to user - socket will already be closed by browser
-        this.emit('error', { type: 'WebSocketError', error: error });
+        this.emit('error', error);
       },
       closed: () => {
         this.abandonConnection();


### PR DESCRIPTION


## What does this PR do?

Hopefully fixes #464 
At the moment each layer (`TransportConnection`, `Connection` and `ConnectionManager`) wrap errors in a `WebSocketError` object, leading to nested errors as described in #464. This PR removes the wrapping from the `Connection` and `ConnectionManager`. All layers emitted to these layers should already be wrapped.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
