### PR TITLE
introduce keepAlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ Disables stats collection, so that connection metrics are not submitted to Pushe
 
 Enables stats collection, so that connection metrics are submitted to Pusher’s servers. These stats can help pusher engineers debug connection issues.
 
+#### `keepAlive` (Boolean) (default: true)
+
+Specifies if we should keep the pusher connection open
+when there is no active subscriptions
+
 #### `enabledTransports` (Array)
 
 Specifies which transports should be used by pusher-js to establish a connection. Useful for applications running in controlled, well-behaving environments. Available transports for web: `ws`, `wss`, `xhr_streaming`, `xhr_polling`, `sockjs`. If you specify your transports in this way, you may miss out on new transports we add in the future.

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -225,6 +225,13 @@ describe("Pusher", function() {
       Pusher.ready();
       expect(pusher.connect).toHaveBeenCalled();
     });
+
+    it("should not connect with keepAlive set to false", function() {
+      Pusher.ready();
+      var pusher = new Pusher("");
+      spyOn(pusher, 'connect');
+      expect(pusher.connect).not.toHaveBeenCalled();
+    })
   });
 
   describe("#connect", function() {
@@ -288,7 +295,15 @@ describe("Pusher", function() {
         pusher.subscribe("xxx");
 
         expect(channel.reinstateSubscription).toHaveBeenCalled();
-      })
+      });
+
+      it("should connect if keepAlive is set to false", function() {
+        var pusher = new Pusher('sa', { keepAlive: false });
+        spyOn(pusher, 'connect');
+        expect(pusher.connect).not.toHaveBeenCalled();
+        pusher.subscribe('ab');
+        expect(pusher.connect).toHaveBeenCalled();
+      });
     });
 
     describe("#unsubscribe", function() {
@@ -316,7 +331,16 @@ describe("Pusher", function() {
         expect(pusher.channel("yyy")).toBe(channel);
         expect(channel.unsubscribe).not.toHaveBeenCalled();
         expect(channel.cancelSubscription).toHaveBeenCalled();
-      })
+      });
+
+      it("should close the connection if keepAlive is set to false", function() {
+        var pusher = new Pusher("foo", { keepAlive: false });
+        pusher.subscribe('bar');
+        spyOn(pusher, 'disconnect');
+        expect(pusher.disconnect).not.toHaveBeenCalled();
+        pusher.unsubscribe('bar');
+        expect(pusher.disconnect).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -32,6 +32,7 @@ export interface Config {
   wsPath: string;
   wsPort: number;
   wssPort: number;
+  keepAlive: boolean;
 
   // these are all optional parameters or overrrides. The customer can set these
   // but it's not strictly necessary
@@ -61,6 +62,7 @@ export function getConfig(opts: Options): Config {
     wsPath: opts.wsPath || Defaults.wsPath,
     wsPort: opts.wsPort || Defaults.wsPort,
     wssPort: opts.wssPort || Defaults.wssPort,
+    keepAlive: Defaults.keepAlive,
 
     enableStats: getEnableStatsConfig(opts),
     httpHost: getHttpHost(opts),
@@ -79,6 +81,9 @@ export function getConfig(opts: Options): Config {
   if ('timelineParams' in opts) config.timelineParams = opts.timelineParams;
   if ('nacl' in opts) {
     config.nacl = opts.nacl;
+  }
+  if ('keepAlive' in opts) {
+    config.keepAlive = opts.keepAlive;
   }
 
   return config;

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -10,6 +10,7 @@ export interface DefaultConfig {
   httpPort: number;
   httpsPort: number;
   httpPath: string;
+  keepAlive: boolean;
   stats_host: string;
   authEndpoint: string;
   authTransport: AuthTransport;
@@ -44,6 +45,7 @@ var Defaults: DefaultConfig = {
   pongTimeout: 30000,
   unavailableTimeout: 10000,
   cluster: 'mt1',
+  keepAlive: true,
 
   // CDN configuration
   cdn_http: CDN_HTTP,

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -20,6 +20,7 @@ export interface Options {
   httpPort?: number;
   httpsPort?: number;
   ignoreNullOrigin?: boolean;
+  keepAlive?: boolean;
   nacl?: nacl;
   pongTimeout?: number;
   statsHost?: string;

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -145,7 +145,7 @@ export default class Pusher {
     Pusher.instances.push(this);
     this.timeline.info({ instances: Pusher.instances.length });
 
-    if (Pusher.isReady) {
+    if (Pusher.isReady && this.config.keepAlive) {
       this.connect();
     }
   }
@@ -216,6 +216,9 @@ export default class Pusher {
   }
 
   subscribe(channel_name: string) {
+    if (!this.config.keepAlive) {
+      this.connect();
+    }
     var channel = this.channels.add(channel_name, this);
     if (channel.subscriptionPending && channel.subscriptionCancelled) {
       channel.reinstateSubscription();
@@ -237,6 +240,10 @@ export default class Pusher {
       if (channel && this.connection.state === 'connected') {
         channel.unsubscribe();
       }
+    }
+
+    if (this.allChannels().length === 0 && !this.config.keepAlive) {
+      this.disconnect();
     }
   }
 

--- a/types/src/core/config.d.ts
+++ b/types/src/core/config.d.ts
@@ -20,6 +20,7 @@ export interface Config {
     wsPath: string;
     wsPort: number;
     wssPort: number;
+    keepAlive: boolean;
     forceTLS?: boolean;
     auth?: AuthOptions;
     authorizer?: AuthorizerGenerator;

--- a/types/src/core/defaults.d.ts
+++ b/types/src/core/defaults.d.ts
@@ -9,6 +9,7 @@ export interface DefaultConfig {
     httpPort: number;
     httpsPort: number;
     httpPath: string;
+    keepAlive: boolean;
     stats_host: string;
     authEndpoint: string;
     authTransport: AuthTransport;

--- a/types/src/core/options.d.ts
+++ b/types/src/core/options.d.ts
@@ -18,6 +18,7 @@ export interface Options {
     httpPort?: number;
     httpsPort?: number;
     ignoreNullOrigin?: boolean;
+    keepAlive?: boolean;
     nacl?: nacl;
     pongTimeout?: number;
     statsHost?: string;


### PR DESCRIPTION
## What does this PR do?

Adds the `keepAlive` config option which defaults to the current behaviour, `true`. If set to `false`, it will only have an active connection to pusher if there is any active channel subscription. There will be no connection to pusher if there no channels subscriptions.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
