### PR TITLE
Adds react-native key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Pusher Channels JavaScript library for browsers, React Native, NodeJS and web workers",
   "main": "dist/node/pusher.js",
   "browser": "dist/web/pusher.js",
+  "react-native": "dist/react-native/pusher.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --config .prettierrc --write 'src/**/*.ts' 'webpack/**/*.js'",


### PR DESCRIPTION
## What does this PR do?

This adds a react-native key to package.json. For some reason, Metro bundler needs this when pusher-js is a nested dependency (otherwise it tries to use the web runtime)
