### PR TITLE
Fix stuck subscription pending state

### DIFF
--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -276,6 +276,19 @@ describe("Channel", function() {
       expect(channel.subscriptionPending).toEqual(false);
     });
 
+    it("should keep #subscriptionPending set as true after a successful authorization", function() {
+      expect(channel.subscriptionPending).toEqual(false);
+
+      channel.subscribe();
+      var authorizeCallback = channel.authorize.calls[0].args[1];
+      authorizeCallback(false, {
+        auth: "one",
+        channel_data: "two"
+      });
+
+      expect(channel.subscriptionPending).toEqual(true);
+    });
+
     it("should do nothing if already subscribed", function() {
       channel.subscribed = true;
 

--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -266,6 +266,16 @@ describe("Channel", function() {
       expect(channel.subscriptionPending).toEqual(true);
     });
 
+    it("should set #subscriptionPending to false on unsuccessful authorization", function() {
+      expect(channel.subscriptionPending).toEqual(false);
+
+      channel.subscribe();
+      var authorizeCallback = channel.authorize.calls[0].args[1];
+      authorizeCallback(new Error("test error"), {auth: ""})
+
+      expect(channel.subscriptionPending).toEqual(false);
+    });
+
     it("should do nothing if already subscribed", function() {
       channel.subscribed = true;
 

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -301,6 +301,15 @@ describe("Pusher", function() {
         expect(channel.unsubscribe).toHaveBeenCalled();
       });
 
+      it("should not unsubscribe the channel if the channel is not subscribed", function() {
+        var channel = pusher.subscribe("yyy");
+        channel.subscribed = false;
+        expect(channel.unsubscribe).not.toHaveBeenCalled();
+
+        pusher.unsubscribe("yyy");
+        expect(channel.unsubscribe).not.toHaveBeenCalled();
+      });
+
       it("should remove the channel from .channels if subscription is not pending", function () {
         var channel = pusher.subscribe("yyy");
         expect(pusher.channel("yyy")).toBe(channel);

--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -294,6 +294,7 @@ describe("Pusher", function() {
     describe("#unsubscribe", function() {
       it("should unsubscribe the channel if subscription is not pending", function() {
         var channel = pusher.subscribe("yyy");
+        channel.subscribed = true;
         expect(channel.unsubscribe).not.toHaveBeenCalled();
 
         pusher.unsubscribe("yyy");

--- a/src/core/channels/channel.ts
+++ b/src/core/channels/channel.ts
@@ -102,6 +102,7 @@ export default class Channel extends EventsDispatcher {
       this.pusher.connection.socket_id,
       (error: Error | null, data: AuthData) => {
         if (error) {
+          this.subscriptionPending = false;
           // Why not bind to 'pusher:subscription_error' a level up, and log there?
           // Binding to this event would cause the warning about no callbacks being
           // bound (see constructor) to be suppressed, that's not what we want.

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -234,7 +234,7 @@ export default class Pusher {
       channel.cancelSubscription();
     } else {
       channel = this.channels.remove(channel_name);
-      if (channel && this.connection.state === 'connected') {
+      if (channel && channel.subscribed) {
         channel.unsubscribe();
       }
     }


### PR DESCRIPTION
## What does this PR do?

Resolves #255 

Currently if an auth request fails, a channel remains in a "subscriptionPending" state meaning it isn't possible to attempt to subscribe to the channel again. This PR clears the "subscriptionPending" state if the auth request fails, meaning it is possible to call `unsubscribe` and then `subscribe` again, to reattempt the subscription.

In order to do this, I made a slight change to the `unsubscribe` method too, so that the unsubscribe message is only sent over the websocket if the channel is actually subscribed. It appears that previously, while the websocket is connected, a channel could only be in the "subscriptionPending" or "subscribed" state. But now it's possible for channels to be in a state where they aren't subscribed and also aren't pending (if the auth request fails). In that case, we shouldn't send the "unsubscribe" message over the websocket when calling unsubscribe, because we aren't subscribed.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
