### PR TITLE
give opts.forceTLS priority over current protocol

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -109,10 +109,10 @@ function getWebsocketHostFromCluster(cluster: string): string {
 }
 
 function shouldUseTLS(opts: Options): boolean {
-  if (Runtime.getProtocol() === 'https:') {
-    return true;
-  } else if (opts.forceTLS === false) {
+  if (opts.forceTLS === false) {
     return false;
+  } else if (Runtime.getProtocol() === 'https:') {
+    return true;
   }
   return true;
 }


### PR DESCRIPTION
## What does this PR do?

hi,

this change gives the forceTLS Option priority over the current protocol, so when hosting the app on https and the (devel) websocket server is running on http (laravel websockets, laradock) there is no implicit changing of the settings, avoiding things like

`Pusher :  : ["Connecting",{"transport":"ws","url":"wss://grabber.test:6001/app/mykey?protocol=7&client=js&version=7.0.2&flash=false"}]`
## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
