### PR TITLE
Upgrade faye-websocket to 0.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "faye-websocket": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@stablelib/base64": "^1.0.0",
     "@stablelib/utf8": "^1.0.0",
     "buffer": "^5.6.0",
-    "faye-websocket": "^0.9.4",
+    "faye-websocket": "^0.11.3",
     "fetch-mock": "git+https://git@github.com/jpatel531/fetch-mock.git",
     "isomorphic-fetch": "^2.2.1",
     "jasmine-node": "^3.0.0",


### PR DESCRIPTION
## What does this PR do?

Fixes #494 - Upgrades the version of `faye-websocket` to 0.11.3.

## Checklist

N/A - only change is dependency version.

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
