### PR TITLE
Update @react-native-community/netinfo to 5.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@react-native-community/netinfo": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.1.1.tgz",
-      "integrity": "sha512-E5AQ2D0qR/uQ7heGSCT8LdDIqGM2Gle7bH8WoQO4zExn4pqz9ZJT1UyysjLnpJthejOU//owbydWqIZE+JNpSA==",
+      "version": "5.9.10",
+      "resolved": "https://registry.jupiter.co/@react-native-community%2fnetinfo/-/netinfo-5.9.10.tgz",
+      "integrity": "sha512-1NPlBA2Hu/KWc3EnQcDRPRX0x8Dg9tuQlQQVWVQjlg+u+PjCq7ANEtbikOFKp5yQqfF8tqzU5+84/IfDO8zpiA==",
       "dev": true
     },
     "@stablelib/base64": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/pusher/pusher-js",
   "devDependencies": {
-    "@react-native-community/netinfo": "^4.1.1",
+    "@react-native-community/netinfo": "^5.9.7",
     "@stablelib/base64": "^1.0.0",
     "@stablelib/utf8": "^1.0.0",
     "buffer": "^5.6.0",


### PR DESCRIPTION
## What does this PR do?

Pusher's version of `@react-native-community/netinfo` is out-of-date, which leads to issues in React Native (and Expo), namely the following error (due to mismatched versions):
```
RNCNetInfo.getCurrentState got 2 arguments, expected 3
```
This should resolve the above issue.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
