### PR TITLE
Type error: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

### DIFF
--- a/src/core/auth/auth_transports.ts
+++ b/src/core/auth/auth_transports.ts
@@ -8,4 +8,4 @@ interface AuthTransports {
   [index: string]: AuthTransport;
 }
 
-export { AuthTransport, AuthTransports };
+export type { AuthTransport, AuthTransports };


### PR DESCRIPTION
## What does this PR do?

```
./node_modules/pusher-js/src/core/auth/auth_transports.ts:11:10
Type error: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

   9 | }
  10 | 
> 11 | export { AuthTransport, AuthTransports };
     |          ^
  12 | 
```