### PR TITLE
Document the authEndpoint as being passed to authorizer generators

### DIFF
--- a/src/core/auth/options.ts
+++ b/src/core/auth/options.ts
@@ -26,6 +26,7 @@ export interface AuthorizerGenerator {
 
 export interface AuthorizerOptions {
   authTransport: 'ajax' | 'jsonp';
+  authEndpoint: string;
   auth?: AuthOptions;
   authorizer?: AuthorizerGenerator;
 }


### PR DESCRIPTION
## What does this PR do?

This improves type definitions for the AuthorizerGenerator.

In practice, the implementation passes the full `Config` object, which is why the `authEndpoint` config was available.
However, type definitions only define that `AuthorizerOptions` is passed, so it should expose this `authEndpoint` setting that is used by all implementations

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
