### PR TITLE
Set worker webpack ouput libraryTarget to umd

### DIFF
--- a/webpack/config.worker.js
+++ b/webpack/config.worker.js
@@ -23,7 +23,8 @@ var config = merge(configShared, {
   output: {
     library: 'Pusher',
     path: path.join(__dirname, '../dist/worker'),
-    filename: filename
+    filename: filename,
+    libraryTarget: 'umd'
   },
   resolve: {
     // in order to import the appropriate runtime.ts


### PR DESCRIPTION
## What does this PR do?

This should allow the `pusher-js/worker` to be included in a bundle with the instructions already provided in the README

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
