### PR TITLE
Replace git protocol with HTTPS in gitsubmodules file 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sockjs-client"]
 	path = src/runtimes/web/dom/sockjs
-	url = git://github.com/pusher/sockjs-client.git
+	url = https://github.com/pusher/sockjs-client.git


### PR DESCRIPTION
## What does this PR do?
 -  Replaces the git protocol with HTTPS

More details here https://github.blog/2021-09-01-improving-git-protocol-security-github/
Git protocol is completely dropped as of 15 March 2022

## CHANGELOG

* [FIXED] Replaced GIT protocol with HTTPS #587
