### PR TITLE
Allow presence channel authorization to depend on user authentication

### DIFF
--- a/spec/javascripts/helpers/timers/promises.js
+++ b/spec/javascripts/helpers/timers/promises.js
@@ -1,0 +1,9 @@
+
+const setTimeoutPromise = (duration) => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, duration);
+    });
+}
+export default {
+    setTimeout: setTimeoutPromise
+};

--- a/spec/javascripts/unit/core/channels/presence_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/presence_channel_spec.js
@@ -5,7 +5,7 @@ var Errors = require('core/errors');
 var Factory = require('core/utils/factory').default;
 var Mocks = require("mocks");
 var flatPromise = require("core/utils/flat_promise").default;
-var { setTimeout } = require("timers/promises").default;
+var { setTimeout } = require("../../../helpers/timers/promises").default;
 
 describe("PresenceChannel", function() {
   var pusher;

--- a/spec/javascripts/unit/core/user_spec.js
+++ b/spec/javascripts/unit/core/user_spec.js
@@ -172,6 +172,7 @@ describe("Pusher (User)", function () {
     });
 
     it('should process pusher:signin_success', async function () {
+      pusher.user._signinDoneResolve = jasmine.createSpy('signinDoneResolve');
       transport.emit('message', {
         data: JSON.stringify({
           event: 'pusher:signin_success',
@@ -183,6 +184,7 @@ describe("Pusher (User)", function () {
 
       expect(pusher.user.user_data).toEqual({ id: '1', name: 'test' });
       expect(pusher.user.serverToUserChannel.subscriptionPending).toBe(true);
+      expect(pusher.user._signinDoneResolve).toHaveBeenCalled();
     });
 
     it('should log warning if user_data is not JSON', async function () {
@@ -220,6 +222,7 @@ describe("Pusher (User)", function () {
       expect(barCallback).not.toHaveBeenCalled();
 
       // Sign in successfully
+      pusher.user._signinDoneResolve = jasmine.createSpy('signinDoneResolve');
       transport.emit('message', {
         data: JSON.stringify({
           event: 'pusher:signin_success',
@@ -242,6 +245,7 @@ describe("Pusher (User)", function () {
         'pusher.user.serverToUserChannel.subscribed to be true',
         500
       );
+      expect(pusher.user._signinDoneResolve).toHaveBeenCalled();
 
       // Send events on channel
       transport.emit('message', {
@@ -259,6 +263,7 @@ describe("Pusher (User)", function () {
 
     it('should cleanup the signed in state when disconnected', async function () {
       // Sign in successfully
+      pusher.user._signinDoneResolve = jasmine.createSpy('signinDoneResolve');
       transport.emit('message', {
         data: JSON.stringify({
           event: 'pusher:signin_success',
@@ -281,6 +286,8 @@ describe("Pusher (User)", function () {
         'pusher.user.serverToUserChannel.subscribed to be true',
         500
       );
+      expect(pusher.user._signinDoneResolve).toHaveBeenCalled();
+
       expect(pusher.user.user_data).toEqual({ id: '1', name: 'test' });
       expect(pusher.user.serverToUserChannel.subscribed).toBe(true);
 

--- a/src/core/channels/presence_channel.ts
+++ b/src/core/channels/presence_channel.ts
@@ -39,7 +39,7 @@ export default class PresenceChannel extends PrivateChannel {
             // and allow the presence authorization to continue.
             this.members.setMyID(this.pusher.user.user_data.id);
           } else {
-            let suffix = UrlStore.buildLogSuffix('authenticationEndpoint');
+            let suffix = UrlStore.buildLogSuffix('authorizationEndpoint');
             Logger.error(
               `Invalid auth response for channel '${this.name}', ` +
                 `expected 'channel_data' field. ${suffix}, ` +

--- a/src/core/channels/presence_channel.ts
+++ b/src/core/channels/presence_channel.ts
@@ -20,26 +20,35 @@ export default class PresenceChannel extends PrivateChannel {
     this.members = new Members();
   }
 
-  /** Authenticates the connection as a member of the channel.
+  /** Authorizes the connection as a member of the channel.
    *
    * @param  {String} socketId
    * @param  {Function} callback
    */
   authorize(socketId: string, callback: Function) {
-    super.authorize(socketId, (error, authData) => {
+    super.authorize(socketId, async (error, authData) => {
       if (!error) {
         authData = authData as ChannelAuthorizationData;
-        if (authData.channel_data === undefined) {
-          let suffix = UrlStore.buildLogSuffix('authenticationEndpoint');
-          Logger.error(
-            `Invalid auth response for channel '${this.name}',` +
-              `expected 'channel_data' field. ${suffix}`
-          );
-          callback('Invalid auth response');
-          return;
+        if (authData.channel_data != null) {
+          var channelData = JSON.parse(authData.channel_data);
+          this.members.setMyID(channelData.user_id);
+        } else {
+          await this.pusher.user.signinDonePromise;
+          if (this.pusher.user.user_data != null) {
+            // If the user is signed in, get the id of the authenticated user
+            // and allow the presence authorization to continue.
+            this.members.setMyID(this.pusher.user.user_data.id);
+          } else {
+            let suffix = UrlStore.buildLogSuffix('authenticationEndpoint');
+            Logger.error(
+              `Invalid auth response for channel '${this.name}', ` +
+                `expected 'channel_data' field. ${suffix}, ` +
+                `or the user should be signed in.`
+            );
+            callback('Invalid auth response');
+            return;
+          }
         }
-        var channelData = JSON.parse(authData.channel_data);
-        this.members.setMyID(channelData.user_id);
       }
       callback(error, authData);
     });

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -170,7 +170,8 @@ export default class UserFacade extends EventsDispatcher {
     const setDone = () => {
       (promise as any).done = true;
     };
-    this.signinDonePromise = promise.then(setDone).catch(setDone);
+    promise.then(setDone).catch(setDone);
+    this.signinDonePromise = promise;
     this._signinDoneResolve = resolve;
   }
 }

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -6,12 +6,15 @@ import {
 } from './auth/options';
 import Channel from './channels/channel';
 import EventsDispatcher from './events/dispatcher';
+import flatPromise from './utils/flat_promise';
 
 export default class UserFacade extends EventsDispatcher {
   pusher: Pusher;
   signin_requested: boolean = false;
   user_data: any = null;
   serverToUserChannel: Channel = null;
+  signinDonePromise: Promise<any> = null;
+  private _signinDoneResolve: Function = null;
 
   public constructor(pusher: Pusher) {
     super(function(eventName, data) {
@@ -22,10 +25,10 @@ export default class UserFacade extends EventsDispatcher {
       this._signin();
     });
     this.pusher.connection.bind('connecting', () => {
-      this._disconnect();
+      this._cleanup();
     });
     this.pusher.connection.bind('disconnected', () => {
-      this._disconnect();
+      this._cleanup();
     });
     this.pusher.connection.bind('message', event => {
       var eventName = event.event;
@@ -55,41 +58,45 @@ export default class UserFacade extends EventsDispatcher {
       return;
     }
 
+    this._newSigninPromiseIfNeeded();
+
     if (this.pusher.connection.state !== 'connected') {
       // Signin will be attempted when the connection is connected
       return;
     }
 
-    const onAuthorize: UserAuthenticationCallback = (
-      err,
-      authData: UserAuthenticationData
-    ) => {
-      if (err) {
-        Logger.warn(`Error during signin: ${err}`);
-        return;
-      }
-
-      this.pusher.send_event('pusher:signin', {
-        auth: authData.auth,
-        user_data: authData.user_data
-      });
-
-      // Later when we get pusher:singin_success event, the user will be marked as signed in
-    };
-
     this.pusher.config.userAuthenticator(
       {
         socketId: this.pusher.connection.socket_id
       },
-      onAuthorize
+      this._onAuthorize
     );
   }
+
+  private _onAuthorize: UserAuthenticationCallback = (
+    err,
+    authData: UserAuthenticationData
+  ) => {
+    if (err) {
+      Logger.warn(`Error during signin: ${err}`);
+      this._cleanup();
+      return;
+    }
+
+    this.pusher.send_event('pusher:signin', {
+      auth: authData.auth,
+      user_data: authData.user_data
+    });
+
+    // Later when we get pusher:singin_success event, the user will be marked as signed in
+  };
 
   private _onSigninSuccess(data: any) {
     try {
       this.user_data = JSON.parse(data.user_data);
     } catch (e) {
       Logger.error(`Failed parsing user data after signin: ${data.user_data}`);
+      this._cleanup();
       return;
     }
 
@@ -97,9 +104,12 @@ export default class UserFacade extends EventsDispatcher {
       Logger.error(
         `user_data doesn't contain an id. user_data: ${this.user_data}`
       );
+      this._cleanup();
       return;
     }
 
+    // Signin succeeded
+    this._signinDoneResolve();
     this._subscribeChannels();
   }
 
@@ -132,12 +142,35 @@ export default class UserFacade extends EventsDispatcher {
     ensure_subscribed(this.serverToUserChannel);
   }
 
-  private _disconnect() {
+  private _cleanup() {
     this.user_data = null;
     if (this.serverToUserChannel) {
       this.serverToUserChannel.unbind_all();
       this.serverToUserChannel.disconnect();
       this.serverToUserChannel = null;
     }
+
+    if (this.signin_requested) {
+      // If signin is in progress and cleanup is called,
+      // Mark the current signin process as done.
+      this._signinDoneResolve();
+    }
+  }
+
+  private _newSigninPromiseIfNeeded() {
+    // If there is a promise and it is not resolved, return without creating a new one.
+    if (this.signinDonePromise && !(this.signinDonePromise as any).done) {
+      return;
+    }
+
+    // This promise is never rejected.
+    // It gets resolved when the signin process is done whether it failed or succeeded
+    const { promise, resolve, reject: _ } = flatPromise();
+    (promise as any).done = false;
+    const setDone = () => {
+      (promise as any).done = true;
+    };
+    this.signinDonePromise = promise.then(setDone).catch(setDone);
+    this._signinDoneResolve = resolve;
   }
 }

--- a/src/core/utils/flat_promise.ts
+++ b/src/core/utils/flat_promise.ts
@@ -1,0 +1,10 @@
+function flatPromise() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export default flatPromise;

--- a/types/src/core/user.d.ts
+++ b/types/src/core/user.d.ts
@@ -6,10 +6,14 @@ export default class UserFacade extends EventsDispatcher {
     signin_requested: boolean;
     user_data: any;
     serverToUserChannel: Channel;
+    signinDonePromise: Promise<any>;
+    private _signinDoneResolve;
     constructor(pusher: Pusher);
     signin(): void;
     private _signin;
+    private _onAuthorize;
     private _onSigninSuccess;
     private _subscribeChannels;
-    private _disconnect;
+    private _cleanup;
+    private _newSigninPromiseIfNeeded;
 }

--- a/types/src/core/utils/flat_promise.d.ts
+++ b/types/src/core/utils/flat_promise.d.ts
@@ -1,0 +1,6 @@
+declare function flatPromise(): {
+    promise: Promise<unknown>;
+    resolve: any;
+    reject: any;
+};
+export default flatPromise;


### PR DESCRIPTION
## What does this PR do?

- Allow presence channel authorization without channel_data to pass through if a user is authenticated
- Properly set the user id from user authentication in the presence channel.
- Allow presence channel authorization without channel_data to wait for an in-progress signin process.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run
