### PR TITLE
Proposed change to #619

### DIFF
--- a/spec/javascripts/unit/core/channels/presence_channel_spec.js
+++ b/spec/javascripts/unit/core/channels/presence_channel_spec.js
@@ -5,7 +5,7 @@ var Errors = require('core/errors');
 var Factory = require('core/utils/factory').default;
 var Mocks = require("mocks");
 var flatPromise = require("core/utils/flat_promise").default;
-var { setTimeout } = require("timers/promises").default;
+var { setTimeout } = require("../../../helpers/timers/promises").default;
 
 describe("PresenceChannel", function() {
   var pusher;

--- a/spec/javascripts/unit/core/user_spec.js
+++ b/spec/javascripts/unit/core/user_spec.js
@@ -82,7 +82,7 @@ describe("Pusher (User)", function () {
       });
 
       pusher.connection.state = "connected";
-      pusher.connection.emit('connected');
+      pusher.connection.emit('state_change', {previous:'connecting', current:'connected'});
 
       expect(pusher.config.userAuthenticator).toHaveBeenCalledWith(
         { socketId: "1.23" },
@@ -116,11 +116,11 @@ describe("Pusher (User)", function () {
       pusher.config.userAuthenticator.calls.reset()
 
       pusher.connection.state == "disconnected";
-      pusher.connection.emit("disconnected");
+      pusher.connection.emit('state_change', {previous:'connected', current:'disconnected'});
       pusher.connection.state == "connecting";
-      pusher.connection.emit("connecting");
+      pusher.connection.emit('state_change', {previous:'disconnected', current:'connecting'});
       pusher.connection.state == "connected";
-      pusher.connection.emit("connected");
+      pusher.connection.emit('state_change', {previous:'connecting', current:'connected'});
 
       expect(pusher.config.userAuthenticator).toHaveBeenCalledWith(
         { socketId: "1.23" },
@@ -134,7 +134,7 @@ describe("Pusher (User)", function () {
 
     it("should not signin when the connection is connected if signin() was never called", function () {
       pusher.connection.state = "connected";
-      pusher.connection.emit('connected');
+      pusher.connection.emit('state_change', {previous:'connecting', current:'connected'});
       expect(pusher.config.userAuthenticator).not.toHaveBeenCalled();
     })
 
@@ -292,7 +292,7 @@ describe("Pusher (User)", function () {
       expect(pusher.user.serverToUserChannel.subscribed).toBe(true);
 
       // Disconnect
-      pusher.connection.emit('disconnected');
+      pusher.connection.emit('state_change', {previous:'connected', current:'disconnected'});
 
       expect(pusher.user.user_data).toEqual(null);
       expect(pusher.user.serverToUserChannel).toEqual(null);

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -21,11 +21,11 @@ export default class UserFacade extends EventsDispatcher {
       Logger.debug('No callbacks on user for ' + eventName);
     });
     this.pusher = pusher;
-    this.pusher.connection.bind('state_change', ({previous, current}) => {
-      if (previous !=='connected' && current === 'connected') {
+    this.pusher.connection.bind('state_change', ({ previous, current }) => {
+      if (previous !== 'connected' && current === 'connected') {
         this._signin();
       }
-      if (previous ==='connected' && current !== 'connected') {
+      if (previous === 'connected' && current !== 'connected') {
         this._cleanup();
         this._newSigninPromiseIfNeeded();
       }

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -27,6 +27,7 @@ export default class UserFacade extends EventsDispatcher {
       }
       if (previous ==='connected' && current !== 'connected') {
         this._cleanup();
+        this._newSigninPromiseIfNeeded();
       }
     });
     this.pusher.connection.bind('message', event => {

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -21,14 +21,13 @@ export default class UserFacade extends EventsDispatcher {
       Logger.debug('No callbacks on user for ' + eventName);
     });
     this.pusher = pusher;
-    this.pusher.connection.bind('connected', () => {
-      this._signin();
-    });
-    this.pusher.connection.bind('connecting', () => {
-      this._cleanup();
-    });
-    this.pusher.connection.bind('disconnected', () => {
-      this._cleanup();
+    this.pusher.connection.bind('state_change', ({previous, current}) => {
+      if (previous !=='connected' && current === 'connected') {
+        this._signin();
+      }
+      if (previous ==='connected' && current !== 'connected') {
+        this._cleanup();
+      }
     });
     this.pusher.connection.bind('message', event => {
       var eventName = event.event;

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -158,6 +158,10 @@ export default class UserFacade extends EventsDispatcher {
   }
 
   private _newSigninPromiseIfNeeded() {
+    if (!this.signin_requested) {
+      return;
+    }
+
     // If there is a promise and it is not resolved, return without creating a new one.
     if (this.signinDonePromise && !(this.signinDonePromise as any).done) {
       return;


### PR DESCRIPTION
## What does this PR do?

The following lines of code handles connection state changes. They were initially coded in this way to match how a similar situation is coded for channel authorization.

https://github.com/pusher/pusher-js/blob/5a73cb9b88130cf5b0a3abcc7dfa33ba1468efef/src/core/user.ts#L24-L32

Here is the analogous code for channels:

https://github.com/pusher/pusher-js/blob/5a73cb9b88130cf5b0a3abcc7dfa33ba1468efef/src/core/pusher.ts#L116-L117

https://github.com/pusher/pusher-js/blob/5a73cb9b88130cf5b0a3abcc7dfa33ba1468efef/src/core/pusher.ts#L137-L142

**What is the problem in doing it this way and why propose a different one?**

Both implementations work fine with the rest of the code and the expected behaviour for the intended use cases of the library. However, the current way of coding it is misleading in a way where the reality will not meet library developer's expectation. Therefore, changing the code now with the proposal in this PR makes the behavior simpler and more predictable. This way it's easy for the library developer to work on new feature with more confidence.

As a library developer, I would expect the anywhere in the code I can `await` on the `signinDonePromise` and the waiting function will get notified when the signin process is done. However, this is not always the case (his the misaligned expectation). The `signinDonePromise` is swapped with a new promise when the connection state goes to `disconnected` and is swapped again when the connection state goes to `connecting`. With each swap, the current promise is resolved and a new one is generated. So imagine the following scenario:
- The connection state changes to `disconnected`
- The promise is swapped. Let's call the created promise "Promise 1"
- Another place in the code gets triggered when the connection state is `disconnected` and `await`s for "Promise 1"
- The connection state changes to `connecting`
- The promise is swapped. Let's call the created promise "Promise 2"
- This will already trigger the code that was waiting for "Promise 1" which now expects that the signin process is done while it's not done. That code will fail because it will not find any user object set because the signin process is not done yet.

**How does the proposed change make the situation better?**

The changed makes the situation better in two folds:
1. Swapping the promise only happens _once_, when the state of the connection goes from `connected` to any other state.  Therefore, the promise you are waiting for will only be resolved when the signin process is finished (with success or failure).
2. There is always a pending promise for you to wait for if the signin is previously requests and the signin process didn't fail. In the previous code, when the connection is disconnected, no new promise will be created for you to wait on. The exisitng promise after the connection is disconnected will be resolved and not swapped with a new one. Therefore, there wouldn't be anyway for you to wait for the coming sign in process when the connection is connected.

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run
