### PR TITLE
Update release_pr workflow to not pull from private repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,7 @@
 - [ ] All tests are passing.
 - [ ] New or changed API methods have been documented.
 - [ ] `npm run format` has been run
+
+## CHANGELOG
+
+- [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -19,8 +19,7 @@ jobs:
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
-          repository: pusher/actions
-          token: ${{ secrets.PUSHER_CI_GITHUB_PRIVATE_TOKEN }}
+          repository: pusher/public_actions
           path: .github/actions
       - uses: ./.github/actions/prepare-version-bump
         id: bump


### PR DESCRIPTION
Update release_pr workflow to not pull from private repo cos that won't
work on external PRs.

The release_pr doesn't work on external PRs because it depends on an
action from a private repo (pusher/actions). External PRs can't use
GitHub Secrets to run Actions which is required in this case to copy an
action from a private repo.

Related to https://github.com/pusher/public_actions/pull/1
