### PR TITLE
Fixed default value: channelAuthorization.endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For more information see [authenticating users](https://pusher.com/docs/channels
 
 Object containing the configuration for user authorization. Valid keys are:
 
-* `endpoint` (String) - Endpoint on your server that will return the authorization signature needed for private and presence channels. Defaults to `/pusher/user-auth`.
+* `endpoint` (String) - Endpoint on your server that will return the authorization signature needed for private and presence channels. Defaults to `/pusher/auth`.
 
 * `transport` (String) - Defines how the authorization endpoint will be called. There are two options available:
   * `ajax` - the **default** option where an `XMLHttpRequest` object will be used to make a request. The parameters will be passed as `POST` parameters.


### PR DESCRIPTION
## What does this PR do?

I've noticed that the documentation for the default value of `channelAuthorization.endpoint` is not correct. It says that the default value is `/pusher/user-auth`, while it looks like it should be `/pusher/auth`. This PR fixes it.

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run

## CHANGELOG

- [FIXED] Fixed documentation for default value of `channelAuthorization.endpoint`
