### PR TITLE
ISSUE-651 - Fix 'window is not defined' error in worker context

### DIFF
--- a/src/runtimes/worker/runtime.ts
+++ b/src/runtimes/worker/runtime.ts
@@ -62,7 +62,7 @@ const Worker: Runtime = {
      * Return values in the range of [0, 1[
      */
     const random = function() {
-      const crypto = window.crypto || window['msCrypto'];
+      const crypto = self.crypto || self['msCrypto'];
       const random = crypto.getRandomValues(new Uint32Array(1))[0];
 
       return random / 2 ** 32;


### PR DESCRIPTION
## What does this PR do?

Fixes the `Reference error: window is not defined` error when calling `randomInt()` function in a worker context.

## Checklist

- [X] All new functionality has tests.
- [ ] All tests are passing.
- [X] New or changed API methods have been documented.
- [X] `npm run format` has been run

## CHANGELOG

- [FIXED] Fix `Reference error: window is not defined` error when calling `randomInt()` function in a worker context.
