### PR TITLE
remove extra blank parameter from log messages

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -40,7 +40,7 @@ class Logger {
     defaultLoggingFunction: (message: string) => void,
     ...args: any[]
   ) {
-    var message = stringify.apply(this, arguments);
+    var message = stringify.apply(this, args);
     if (Pusher.log) {
       Pusher.log(message);
     } else if (Pusher.logToConsole) {


### PR DESCRIPTION
This log function takes the logger function as the first argument, and the data to log as the remaining (varargs) arguments. However, it passes all of the arguments including the logger function to stringify, which results in an extra blank field in the output.

Example before:

````
Pusher :  : ["Event sent",{"event":"pusher:ping","data":{}}]
```

Example after:

```
Pusher : ["Event sent",{"event":"pusher:ping","data":{}}]
```