### PR TITLE
fix(worker): return the right status in pusher worker

### DIFF
--- a/src/runtimes/worker/auth/fetch_auth.ts
+++ b/src/runtimes/worker/auth/fetch_auth.ts
@@ -45,7 +45,7 @@ var fetchAuth: AuthTransport = function(
         return response.text();
       }
       throw new HTTPAuthError(
-        200,
+        status,
         `Could not get ${authRequestType.toString()} info from your auth endpoint, status: ${status}`
       );
     })


### PR DESCRIPTION
## What does this PR do?

[Description here]
When we receive a `subscription:error` event espacially when the token expires we receive status `200` instead of `401`, we did a local patch in our end its working fine with these change proposed here

## Checklist

- [ ] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run

## CHANGELOG

- [CHANGED] specify the right status when a error is thrown, for the pusher worker instance