### PR TITLE
Add ConnectionState type

### DIFF
--- a/src/core/connection/connection_manager.ts
+++ b/src/core/connection/connection_manager.ts
@@ -18,6 +18,8 @@ import {
 } from './callbacks';
 import Action from './protocol/action';
 
+export type ConnectionState = 'initialized' | 'connecting' | 'connected' | 'unavailable' | 'failed' | 'disconnected';
+
 /** Manages connection to Pusher.
  *
  * Uses a strategy (currently only default), timers and network availability
@@ -47,7 +49,7 @@ import Action from './protocol/action';
 export default class ConnectionManager extends EventsDispatcher {
   key: string;
   options: ConnectionManagerOptions;
-  state: string;
+  state: ConnectionState;
   connection: Connection;
   usingTLS: boolean;
   timeline: Timeline;


### PR DESCRIPTION
A proposal for adding the union of connection states according to [this docs page](https://pusher.com/docs/channels/using_channels/connection/#available-states).

## What does this PR do?

Adds the union type for all the different connection status strings. There could be more places that this is used. This is only a demonstration of my request.

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run

## CHANGELOG

- [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
