### PR TITLE
Persist initial Pusher options

### DIFF
--- a/spec/javascripts/unit/core/pusher_spec.js
+++ b/spec/javascripts/unit/core/pusher_spec.js
@@ -346,6 +346,23 @@ describe("Pusher", function() {
           "channel"
         );
       });
+
+      it('should keep the persist the previous options', () => {
+        var authorizeSpy = jasmine.createSpy("authorizeSpy");
+        const options = {
+          cluster: "mt1",
+          enableStats: true,
+          channelAuthorization: {
+            customHandler: authorizeSpy
+          }
+        };
+
+        var pusher = new Pusher("foo", options);
+        pusher.connect();
+        pusher.switchCluster({ appKey: 'bar', cluster: 'us3' });
+
+        expect(pusher.options).toEqual({ ...options, cluster: 'us3' });
+      })
     })
 
     describe("#unsubscribe", function() {

--- a/src/core/auth/options.ts
+++ b/src/core/auth/options.ts
@@ -51,23 +51,6 @@ export type AuthTransportCallback =
   | ChannelAuthorizationCallback
   | UserAuthenticationCallback;
 
-export interface AuthOptionsT<AuthHandler> {
-  transport: 'ajax' | 'jsonp';
-  endpoint: string;
-  params?: any;
-  headers?: any;
-  paramsProvider?: () => any;
-  headersProvider?: () => any;
-  customHandler?: AuthHandler;
-}
-
-export declare type UserAuthenticationOptions = AuthOptionsT<
-  UserAuthenticationHandler
->;
-export declare type ChannelAuthorizationOptions = AuthOptionsT<
-  ChannelAuthorizationHandler
->;
-
 export interface InternalAuthOptions {
   transport: 'ajax' | 'jsonp';
   endpoint: string;
@@ -76,3 +59,16 @@ export interface InternalAuthOptions {
   paramsProvider?: () => any;
   headersProvider?: () => any;
 }
+
+export type CustomAuthOptions<AuthHandler> = {
+  customHandler: AuthHandler;
+}
+
+export type AuthOptionsT<AuthHandler> = InternalAuthOptions | CustomAuthOptions<AuthHandler>
+
+export declare type UserAuthenticationOptions = AuthOptionsT<
+  UserAuthenticationHandler
+>;
+export declare type ChannelAuthorizationOptions = AuthOptionsT<
+  ChannelAuthorizationHandler
+>;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,9 @@ import Defaults from './defaults';
 import {
   ChannelAuthorizationHandler,
   UserAuthenticationHandler,
-  ChannelAuthorizationOptions
+  ChannelAuthorizationOptions,
+  AuthOptionsT,
+  CustomAuthOptions
 } from './auth/options';
 import UserAuthenticator from './auth/user_authenticator';
 import ChannelAuthorizer from './auth/channel_authorizer';
@@ -131,15 +133,17 @@ function getEnableStatsConfig(opts: Options): boolean {
   return false;
 }
 
+const hasCustomHandler = <T>(auth: AuthOptionsT<T>): auth is CustomAuthOptions<T> => {
+ return 'customHandler' in auth && auth['customHandler'] != null;
+}
+
 function buildUserAuthenticator(opts: Options): UserAuthenticationHandler {
   const userAuthentication = {
     ...Defaults.userAuthentication,
     ...opts.userAuthentication
   };
-  if (
-    'customHandler' in userAuthentication &&
-    userAuthentication['customHandler'] != null
-  ) {
+
+  if (hasCustomHandler(userAuthentication)) {
     return userAuthentication['customHandler'];
   }
 
@@ -158,17 +162,22 @@ function buildChannelAuth(opts: Options, pusher): ChannelAuthorizationOptions {
       transport: opts.authTransport || Defaults.authTransport,
       endpoint: opts.authEndpoint || Defaults.authEndpoint
     };
+
     if ('auth' in opts) {
       if ('params' in opts.auth) channelAuthorization.params = opts.auth.params;
       if ('headers' in opts.auth)
         channelAuthorization.headers = opts.auth.headers;
     }
-    if ('authorizer' in opts)
-      channelAuthorization.customHandler = ChannelAuthorizerProxy(
-        pusher,
-        channelAuthorization,
-        opts.authorizer
-      );
+
+    if ('authorizer' in opts) {
+      return {
+        customHandler: ChannelAuthorizerProxy(
+          pusher,
+          channelAuthorization,
+          opts.authorizer
+        )
+      }
+    }
   }
   return channelAuthorization;
 }
@@ -178,10 +187,8 @@ function buildChannelAuthorizer(
   pusher
 ): ChannelAuthorizationHandler {
   const channelAuthorization = buildChannelAuth(opts, pusher);
-  if (
-    'customHandler' in channelAuthorization &&
-    channelAuthorization['customHandler'] != null
-  ) {
+
+  if (hasCustomHandler(channelAuthorization)) {
     return channelAuthorization['customHandler'];
   }
 

--- a/src/core/pusher.ts
+++ b/src/core/pusher.ts
@@ -63,7 +63,8 @@ export default class Pusher {
     checkAppKey(app_key);
     validateOptions(options);
     this.key = app_key;
-    this.config = getConfig(options, this);
+    this.options = options;
+    this.config = getConfig(this.options, this);
 
     this.channels = Factory.createChannels();
     this.global_emitter = new EventsDispatcher();

--- a/types/src/core/auth/options.d.ts
+++ b/types/src/core/auth/options.d.ts
@@ -27,17 +27,6 @@ export interface UserAuthenticationHandler {
     (params: UserAuthenticationRequestParams, callback: UserAuthenticationCallback): void;
 }
 export type AuthTransportCallback = ChannelAuthorizationCallback | UserAuthenticationCallback;
-export interface AuthOptionsT<AuthHandler> {
-    transport: 'ajax' | 'jsonp';
-    endpoint: string;
-    params?: any;
-    headers?: any;
-    paramsProvider?: () => any;
-    headersProvider?: () => any;
-    customHandler?: AuthHandler;
-}
-export declare type UserAuthenticationOptions = AuthOptionsT<UserAuthenticationHandler>;
-export declare type ChannelAuthorizationOptions = AuthOptionsT<ChannelAuthorizationHandler>;
 export interface InternalAuthOptions {
     transport: 'ajax' | 'jsonp';
     endpoint: string;
@@ -46,3 +35,9 @@ export interface InternalAuthOptions {
     paramsProvider?: () => any;
     headersProvider?: () => any;
 }
+export type CustomAuthOptions<AuthHandler> = {
+    customHandler: AuthHandler;
+};
+export type AuthOptionsT<AuthHandler> = InternalAuthOptions | CustomAuthOptions<AuthHandler>;
+export declare type UserAuthenticationOptions = AuthOptionsT<UserAuthenticationHandler>;
+export declare type ChannelAuthorizationOptions = AuthOptionsT<ChannelAuthorizationHandler>;


### PR DESCRIPTION
## What does this PR do?

Initial Pusher Options passed to the constructor were ignored when calling `pusher.switchCluster`.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run

## CHANGELOG

- [FIXED] Persist Initial Pusher Options
- [FIXED] Authorization Custom Handler typing https://github.com/pusher/pusher-js/issues/715
