### PR TITLE
Example: JS pusher.trigger() returns a Promise and should be awaited

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ A few gotchas to consider when using client events:
 - The event name for client events *must* start with `client-`
 
 ```
-channel.trigger('client-my-event', {message: 'Hello, world!'})
+await channel.trigger('client-my-event', {message: 'Hello, world!'})
 ```
 
 


### PR DESCRIPTION
The example code for calling `channel.trigger(...)` is incorrect.

The function `Pusher.trigger(...);` returns `Promise<Pusher.Response>` and therefore should be awaited.

If this call is not awaited then the trigger call becomes unreliable.