### PR TITLE
Fix `window is not defined` crash when importing in SSR environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ cjs:
 	INCLUDE_TWEETNACL=true MINIMIZE=false node_modules/webpack/bin/webpack.js --config=webpack/config.cjs.js
 
 .PHONY: cjs_unit
-cjs_unit:
+cjs_unit: cjs
 	node_modules/.bin/jasmine --config=spec/config/jasmine/cjs.json
 
 .PHONY: react-native

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 .PHONY: build_all
-build_all: web react-native node worker
+build_all: web cjs react-native node worker
 
 .PHONY: json2
 json2:
@@ -21,6 +21,18 @@ web:
 
 	@echo "Minified Browser Release (with encryption)"
 	INCLUDE_TWEETNACL=true node_modules/webpack/bin/webpack.js --config=webpack/config.web.js
+
+.PHONY: cjs
+cjs:
+	@echo "CommonJS Release:"
+	MINIMIZE=false node_modules/webpack/bin/webpack.js --config=webpack/config.cjs.js
+
+	@echo "CommonJS Release (with encryption)"
+	INCLUDE_TWEETNACL=true MINIMIZE=false node_modules/webpack/bin/webpack.js --config=webpack/config.cjs.js
+
+.PHONY: cjs_unit
+cjs_unit:
+	node_modules/.bin/jasmine --config=spec/config/jasmine/cjs.json
 
 .PHONY: react-native
 react-native:

--- a/cjs/index.d.ts
+++ b/cjs/index.d.ts
@@ -1,0 +1,29 @@
+export {
+  DeprecatedAuthOptions,
+  ChannelAuthorizerGenerator
+} from '../types/src/core/auth/deprecated_channel_authorizer';
+export {
+  UserAuthenticationOptions,
+  ChannelAuthorizationOptions,
+  ChannelAuthorizationHandler,
+  UserAuthenticationHandler,
+  ChannelAuthorizationCallback,
+  UserAuthenticationCallback
+} from '../types/src/core/auth/options';
+export { Options } from '../types/src/core/options';
+
+export { default as Channel } from '../types/src/core/channels/channel';
+export { default as PresenceChannel } from '../types/src/core/channels/presence_channel';
+export { default as Members } from '../types/src/core/channels/members';
+export { default as Runtime } from '../types/src/runtimes/interface';
+export { default as ConnectionManager } from '../types/src/core/connection/connection_manager';
+
+export { default } from '../types/src/core/pusher';
+
+// The following types are provided for backward compatibility
+export {
+  DeprecatedAuthOptions as AuthOptions,
+  DeprecatedChannelAuthorizer as Authorizer,
+  ChannelAuthorizerGenerator as AuthorizerGenerator
+} from '../types/src/core/auth/deprecated_channel_authorizer';
+export { ChannelAuthorizationCallback as AuthorizerCallback } from '../types/src/core/auth/options';

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/cjs/pusher');

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,1 +1,2 @@
+// See cjs/index.d.ts for TypeScript declarations.
 module.exports = require('../dist/cjs/pusher');

--- a/cjs/with-encryption/index.d.ts
+++ b/cjs/with-encryption/index.d.ts
@@ -1,0 +1,29 @@
+export {
+  DeprecatedAuthOptions,
+  ChannelAuthorizerGenerator
+} from '../../types/src/core/auth/deprecated_channel_authorizer';
+export {
+  ChannelAuthorizationOptions,
+  UserAuthenticationOptions,
+  ChannelAuthorizationHandler,
+  UserAuthenticationHandler,
+  ChannelAuthorizationCallback,
+  UserAuthenticationCallback
+} from '../../types/src/core/auth/options';
+export { Options } from '../../types/src/core/options';
+
+export { default as Channel } from '../../types/src/core/channels/channel';
+export { default as PresenceChannel } from '../../types/src/core/channels/presence_channel';
+export { default as Members } from '../../types/src/core/channels/members';
+export { default as Runtime } from '../../types/src/runtimes/interface';
+export { default as ConnectionManager } from '../../types/src/core/connection/connection_manager';
+
+export { default } from '../../types/src/core/pusher';
+
+// The following types are provided for backward compatibility
+export {
+  DeprecatedAuthOptions as AuthOptions,
+  DeprecatedChannelAuthorizer as Authorizer,
+  ChannelAuthorizerGenerator as AuthorizerGenerator
+} from '../../types/src/core/auth/deprecated_channel_authorizer';
+export { ChannelAuthorizationCallback as AuthorizerCallback } from '../../types/src/core/auth/options';

--- a/cjs/with-encryption/index.js
+++ b/cjs/with-encryption/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../dist/cjs/pusher-with-encryption');

--- a/cjs/with-encryption/index.js
+++ b/cjs/with-encryption/index.js
@@ -1,1 +1,2 @@
+// See cjs/with-encryption/index.d.ts for TypeScript declarations.
 module.exports = require('../../dist/cjs/pusher-with-encryption');

--- a/spec/config/jasmine/cjs.json
+++ b/spec/config/jasmine/cjs.json
@@ -1,0 +1,10 @@
+{
+  "spec_dir": "spec/javascripts/unit/cjs",
+  "spec_files": [
+    "**/*spec.js"
+  ],
+  "failSpecWithNoExpectations": false,
+  "stopSpecOnExpectationFailure": false,
+  "stopOnSpecFailure": false,
+  "random": false
+}

--- a/spec/javascripts/unit/cjs/ssr_import_spec.js
+++ b/spec/javascripts/unit/cjs/ssr_import_spec.js
@@ -1,0 +1,15 @@
+describe('CJS build SSR import', function () {
+  it('should import pusher-js/cjs without crashing in a non-browser environment', function () {
+    expect(typeof window).toBe('undefined');
+    expect(function () {
+      require('../../../../cjs');
+    }).not.toThrow();
+  });
+
+  it('should import pusher-js/cjs/with-encryption without crashing in a non-browser environment', function () {
+    expect(typeof window).toBe('undefined');
+    expect(function () {
+      require('../../../../cjs/with-encryption');
+    }).not.toThrow();
+  });
+});

--- a/src/core/base64.ts
+++ b/src/core/base64.ts
@@ -43,7 +43,7 @@ var cb_encode = function (ccc) {
 };
 
 var btoa =
-  global.btoa ||
+  (typeof global !== 'undefined' && global.btoa) ||
   function (b) {
     return b.replace(/[\s\S]{1,3}/g, cb_encode);
   };

--- a/src/runtimes/web/net_info.ts
+++ b/src/runtimes/web/net_info.ts
@@ -12,7 +12,10 @@ export class NetInfo extends EventsDispatcher implements Reachability {
     super();
     var self = this;
     // This is okay, as IE doesn't support this stuff anyway.
-    if (window.addEventListener !== undefined) {
+    if (
+      typeof window !== 'undefined' &&
+      window.addEventListener !== undefined
+    ) {
       window.addEventListener(
         'online',
         function () {

--- a/src/runtimes/web/runtime.ts
+++ b/src/runtimes/web/runtime.ts
@@ -40,14 +40,16 @@ var Runtime: Browser = {
   },
 
   setup(PusherClass): void {
-    (<any>window).Pusher = PusherClass; // JSONp requires Pusher to be in the global scope.
-    var initializeOnDocumentBody = () => {
-      this.onDocumentBody(PusherClass.ready);
-    };
-    if (!(<any>window).JSON) {
-      Dependencies.load('json2', {}, initializeOnDocumentBody);
-    } else {
-      initializeOnDocumentBody();
+    if (typeof window !== 'undefined') {
+      (<any>window).Pusher = PusherClass; // JSONp requires Pusher to be in the global scope.
+      var initializeOnDocumentBody = () => {
+        this.onDocumentBody(PusherClass.ready);
+      };
+      if (!(<any>window).JSON) {
+        Dependencies.load('json2', {}, initializeOnDocumentBody);
+      } else {
+        initializeOnDocumentBody();
+      }
     }
   },
 

--- a/webpack/config.cjs.js
+++ b/webpack/config.cjs.js
@@ -1,0 +1,30 @@
+var path = require('path');
+var webpack = require('webpack');
+const { merge } = require('webpack-merge');
+var configShared = require('./config.shared');
+
+var entry = './src/core/pusher.js';
+var filename = 'pusher.js';
+if (process.env.INCLUDE_TWEETNACL === 'true') {
+  entry = './src/core/pusher-with-encryption.js';
+  filename = 'pusher-with-encryption.js';
+}
+
+module.exports = merge({}, configShared, {
+  entry: {
+    pusher: entry,
+  },
+  output: {
+    library: { type: 'commonjs2' },
+    path: path.join(__dirname, '../dist/cjs'),
+    filename: filename,
+  },
+  resolve: {
+    modules: ['src/runtimes/web'],
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      RUNTIME: JSON.stringify('web'),
+    }),
+  ],
+});


### PR DESCRIPTION
## What does this PR do?

Importing `pusher-js/with-encryption` in server-side rendering frameworks (Next.js, SvelteKit, etc.) throws `ReferenceError: window is not defined` because the web build references `window` in code that executes at module load time.

There are three crash sites:

1. **`net_info.ts`** — `new NetInfo()` is called at module scope (line 50), and its constructor calls `window.addEventListener` immediately
2. **`runtime.ts` `setup()`** — assigns `window.Pusher`, checks `window.JSON`, and calls `document.body` during setup, which runs at module load
3. **`base64.ts`** — references `global.btoa` without checking if `global` exists (edge case in some SSR bundlers)

This PR adds `typeof window !== 'undefined'` guards to each of these, and adds a CJS build as an explicit SSR-friendly import path (`pusher-js/cjs` and `pusher-js/cjs/with-encryption`). The CJS webpack config is written for webpack 5 compatibility.

The approach and source fixes are based on work by @AlexVipond in #819.

Closes #624, #857.

## CHANGELOG

- [FIXED] Fix `window is not defined` crash when importing `pusher-js/with-encryption` in SSR environments (Next.js, SvelteKit, etc.)
- [ADDED] Add `pusher-js/cjs` and `pusher-js/cjs/with-encryption` as SSR-friendly CJS import paths