### PR TITLE
Add runtime type declaration for ts-loader compatibility

### DIFF
--- a/src/runtimes/runtime.d.ts
+++ b/src/runtimes/runtime.d.ts
@@ -1,0 +1,4 @@
+import RuntimeInterface from './interface';
+
+declare const Runtime: RuntimeInterface;
+export default Runtime;


### PR DESCRIPTION
## Summary

- ts-loader 9.x uses TypeScript's module resolver strictly, whereas 6.x allowed webpack's own resolver to handle bare module imports like `import Runtime from 'runtime'`
- After upgrading ts-loader to 9.5.7, all 19 source files that import `runtime` produce `TS2307: Cannot find module 'runtime'` warnings during the webpack build
- Adds `src/runtimes/runtime.d.ts` — a declaration-only file that gives TypeScript a type to resolve to via the existing `tsconfig.json` paths config (`runtimes/*`), while webpack continues to resolve `runtime` to the correct per-target implementation via `resolve.modules`

No changes to `tsconfig.json`, webpack configs, or any source files.

## Test plan

- [x] Webpack build completes without `TS2307: Cannot find module 'runtime'` warnings
- [x] All existing web, node, worker, react-native, and CJS build targets produce correct output
- [x] Unit and integration tests pass