### PR TITLE
Emit pusher:signin_error on user-authentication failure

### DIFF
--- a/spec/javascripts/unit/core/user_spec.js
+++ b/spec/javascripts/unit/core/user_spec.js
@@ -13,6 +13,7 @@ const transports = Runtime.Transports;
 const Network = require("net_info").Network;
 const waitsFor = require("../../helpers/waitsFor");
 var NetInfo = require("net_info").NetInfo;
+var Errors = require("core/errors");
 
 describe("Pusher (User)", function () {
 
@@ -46,6 +47,40 @@ describe("Pusher (User)", function () {
       expect(Logger.warn).toHaveBeenCalledWith(
         "Error during signin: this error"
       );
+    });
+
+    it("should emit pusher:signin_error event on unsuccessful authorization", function () {
+      var onSigninError = jasmine.createSpy("onSigninError");
+      pusher.user.bind("pusher:signin_error", onSigninError);
+      pusher.config.userAuthenticator.and.callFake(function (params, callback) {
+        callback(new Error("test error"), null);
+      });
+      spyOn(Logger, "warn");
+
+      pusher.signin();
+
+      expect(onSigninError).toHaveBeenCalledWith({
+        type: "AuthError",
+        error: "test error"
+      });
+      expect(pusher.send_event).not.toHaveBeenCalled();
+    });
+
+    it("should include the HTTP status in pusher:signin_error when the error is an HTTPAuthError", function () {
+      var onSigninError = jasmine.createSpy("onSigninError");
+      pusher.user.bind("pusher:signin_error", onSigninError);
+      pusher.config.userAuthenticator.and.callFake(function (params, callback) {
+        callback(new Errors.HTTPAuthError(403, "Forbidden"), null);
+      });
+      spyOn(Logger, "warn");
+
+      pusher.signin();
+
+      expect(onSigninError).toHaveBeenCalledWith({
+        type: "AuthError",
+        error: "Forbidden",
+        status: 403
+      });
     });
 
     it("should send pusher:signin event", function () {

--- a/spec/javascripts/unit/core/user_spec.js
+++ b/spec/javascripts/unit/core/user_spec.js
@@ -83,6 +83,57 @@ describe("Pusher (User)", function () {
       });
     });
 
+    it("should include the HTTP status in pusher:signin_error for a 4xx error other than 403", function () {
+      var onSigninError = jasmine.createSpy("onSigninError");
+      pusher.user.bind("pusher:signin_error", onSigninError);
+      pusher.config.userAuthenticator.and.callFake(function (params, callback) {
+        callback(new Errors.HTTPAuthError(401, "Unauthorized"), null);
+      });
+      spyOn(Logger, "warn");
+
+      pusher.signin();
+
+      expect(onSigninError).toHaveBeenCalledWith({
+        type: "AuthError",
+        error: "Unauthorized",
+        status: 401
+      });
+    });
+
+    it("should include the HTTP status in pusher:signin_error for a 5xx error", function () {
+      var onSigninError = jasmine.createSpy("onSigninError");
+      pusher.user.bind("pusher:signin_error", onSigninError);
+      pusher.config.userAuthenticator.and.callFake(function (params, callback) {
+        callback(new Errors.HTTPAuthError(500, "Internal Server Error"), null);
+      });
+      spyOn(Logger, "warn");
+
+      pusher.signin();
+
+      expect(onSigninError).toHaveBeenCalledWith({
+        type: "AuthError",
+        error: "Internal Server Error",
+        status: 500
+      });
+    });
+
+    it("should include a status of 0 in pusher:signin_error when the request never reached the server", function () {
+      var onSigninError = jasmine.createSpy("onSigninError");
+      pusher.user.bind("pusher:signin_error", onSigninError);
+      pusher.config.userAuthenticator.and.callFake(function (params, callback) {
+        callback(new Errors.HTTPAuthError(0, "Connection interrupted"), null);
+      });
+      spyOn(Logger, "warn");
+
+      pusher.signin();
+
+      expect(onSigninError).toHaveBeenCalledWith({
+        type: "AuthError",
+        error: "Connection interrupted",
+        status: 0
+      });
+    });
+
     it("should send pusher:signin event", function () {
       pusher.config.userAuthenticator.and.callFake(function (params, callback) {
         callback(null, {

--- a/src/core/user.ts
+++ b/src/core/user.ts
@@ -8,6 +8,7 @@ import Channel from './channels/channel';
 import WatchlistFacade from './watchlist';
 import EventsDispatcher from './events/dispatcher';
 import flatPromise from './utils/flat_promise';
+import { HTTPAuthError } from './errors';
 
 export default class UserFacade extends EventsDispatcher {
   pusher: Pusher;
@@ -84,6 +85,17 @@ export default class UserFacade extends EventsDispatcher {
   ) => {
     if (err) {
       Logger.warn(`Error during signin: ${err}`);
+      this.emit(
+        'pusher:signin_error',
+        Object.assign(
+          {},
+          {
+            type: 'AuthError',
+            error: err.message,
+          },
+          err instanceof HTTPAuthError ? { status: err.status } : {},
+        ),
+      );
       this._cleanup();
       return;
     }


### PR DESCRIPTION
## Summary

`UserFacade` (the `pusher.user` signin flow) only logged a warning when the user-authentication endpoint returned a non-200 response — there was no way for a consumer to actually catch or react to a signin failure (e.g. a 403). See #900.

This mirrors the existing `pusher:subscription_error` pattern already used for channel authorization (`src/core/channels/channel.ts`): emit a typed `AuthError` event on failure, including the HTTP status when the underlying error is an `HTTPAuthError`.

```js
pusher.user.bind('pusher:signin_error', (err) => {
  if (err.status === 403) { /* handle it */ }
});
```